### PR TITLE
Fix typo that prevent tag(s) to be assigned to new issue

### DIFF
--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -509,7 +509,7 @@ function New-GitHubIssue
     if ($PSBoundParameters.ContainsKey('Body')) { $hashBody['body'] = $Body }
     if ($PSBoundParameters.ContainsKey('Assignee')) { $hashBody['assignees'] = @($Assignee) }
     if ($PSBoundParameters.ContainsKey('Milestone')) { $hashBody['milestone'] = $Milestone }
-    if ($PSBoundParameters.ContainsKey('Label')) { $hashBody['label'] = @($Label) }
+    if ($PSBoundParameters.ContainsKey('Label')) { $hashBody['labels'] = @($Label) }
 
     $params = @{
         'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues"


### PR DESCRIPTION
When using:
```powershell
New-GitHubIssue -OwnerName lazywinadmin -RepositoryName lazywinadmin.github.io -Title PowerShellTest6 -Body test -Label 'blog comments','bug'
```

The labels are not assigned to the new issue.

This PR fix the problem, just a typo.
