### PR TITLE
Add URL config for GitHub Enterprise

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,13 +248,15 @@ Here are some general guidelines
 
 If you want to add a new configuration value to the module, you must modify the following:
  * In `Import-GitHubConfiguration`, update `$config` to declare the new property along with
-   it's default value, being sure that PowerShell will understand what its type is.
+   its default value, being sure that PowerShell will understand what its type is. Properties
+   should be alphabetical.
  * Update `Get-GitHubConfiguration` and add the new property name to the `ValidateSet` list
    so that tab-completion and documentation gets auto-updated. You shouldn't have to add anything
-   to the body of the method.
+   to the body of the method. Property names should be alphabetical.
  * Add a new explicit parameter to `Set-GitHubConfiguration` to receive the property, along with
    updating the CBH (Comment Based Help) by adding a new `.PAREMETER` entry. You shouldn't
-   have to add anything to the body of the method.
+   have to add anything to the body of the method. Parameters should be alphabetical save for the
+   `SessionOnly` switch, which should be last.
 
 ----------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ Here are some general guidelines
 ## Adding New Configuration Properties
 
 If you want to add a new configuration value to the module, you must modify the following:
- * In `Restore-GitHubConfiguration`, update `$config` to declare the new property along with
+ * In `Import-GitHubConfiguration`, update `$config` to declare the new property along with
    it's default value, being sure that PowerShell will understand what its type is.
  * Update `Get-GitHubConfiguration` and add the new property name to the `ValidateSet` list
    so that tab-completion and documentation gets auto-updated. You shouldn't have to add anything

--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -253,7 +253,7 @@ function Get-GitHubConfiguration
 
         Always returns the value for this session, which may or may not be the persisted
         setting (that all depends on whether or not the setting was previously modified
-        during this session using Set-GitHubCOnfiguration -SessionOnly).
+        during this session using Set-GitHubConfiguration -SessionOnly).
 
         The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
 

--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -146,6 +146,11 @@ function Set-GitHubConfiguration
         created/updated and the specified configuration changes will only remain in memory/effect
         for the duration of this PowerShell session.
 
+    .PARAMETER GitHubBaseUrl
+        The base URL of the GitHub instance to communicate with. Defaults to 'github.com'. Provide
+        a different URL when using a GitHub Enterprise server. The server must respond to the
+        standard API interface, for instance, api.github.contoso.com.
+
     .EXAMPLE
         Set-GitHubConfiguration -WebRequestTimeoutSec 120 -SuppressNoTokenWarning
 
@@ -158,6 +163,12 @@ function Set-GitHubConfiguration
 
         Disables the logging of any activity to the logfile specified in LogPath, but for this
         session only.
+
+    .EXAMPLE
+        Set-GitHubConfiguration -GitHubBaseUrl "github.contoso.com"
+
+        Sets all requests to connect to a GitHub Enterprise server running at
+        api.github.contoso.com.
 #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
@@ -197,7 +208,9 @@ function Set-GitHubConfiguration
         [ValidateRange(0, 3600)]
         [int] $WebRequestTimeoutSec,
 
-        [switch] $SessionOnly
+        [switch] $SessionOnly,
+
+        [string] $GitHubBaseUrl
     )
 
     $persistedConfig = $null
@@ -273,7 +286,8 @@ function Get-GitHubConfiguration
             'RetryDelaySeconds',
             'SuppressNoTokenWarning',
             'SuppressTelemetryReminder',
-            'WebRequestTimeoutSec')]
+            'WebRequestTimeoutSec',
+            'GitHubBaseUrl')]
         [string] $Name
     )
 
@@ -606,6 +620,7 @@ function Import-GitHubConfiguration
         'suppressNoTokenWarning' = $false
         'suppressTelemetryReminder' = $false
         'webRequestTimeoutSec' = 0
+        'gitHubBaseUrl' = 'github.com'
     }
 
     $jsonObject = Read-GitHubConfiguration -Path $Path

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -153,7 +153,7 @@ function Invoke-GHRestMethod
 
     $hostName = $(Get-GitHubConfiguration -Name "ApiHostName")
 
-    $url = "https://api.$hostname/$UriFragment"
+    $url = "https://api.$hostName/$UriFragment"
 
     # It's possible that we are directly calling the "nextLink" from a previous command which
     # provides the full URI.  If that's the case, we'll just use exactly what was provided to us.

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -2,9 +2,6 @@
 # Licensed under the MIT License.
 
 @{
-    gitHubApiUrl = 'https://api.github.com'
-    gitHubApiReposUrl = 'https://api.github.com/repos'
-    gitHubApiOrgsUrl = 'https://api.github.com/orgs'
     defaultAcceptHeader = 'application/vnd.github.v3+json'
     mediaTypeVersion = 'v3'
     squirrelAcceptHeader = 'application/vnd.github.squirrel-girl-preview'
@@ -154,7 +151,9 @@ function Invoke-GHRestMethod
     # we'll just always continue the existing one...
     $stopwatch.Start()
 
-    $url = "$script:gitHubApiUrl/$UriFragment"
+    $gitHubApiUrl = "https://api.$(Get-GitHubConfiguration -Name "GitHubBaseUrl")"
+
+    $url = "$gitHubApiUrl/$UriFragment"
 
     # It's possible that we are directly calling the "nextLink" from a previous command which
     # provides the full URI.  If that's the case, we'll just use exactly what was provided to us.
@@ -735,8 +734,10 @@ function Split-GitHubUri
         repositoryName = [String]::Empty
     }
 
-    if (($Uri -match '^https?://(?:www.)?github.com/([^/]+)/?([^/]+)?(?:/.*)?$') -or
-        ($Uri -match '^https?://api.github.com/repos/([^/]+)/?([^/]+)?(?:/.*)?$'))
+    $gitHubUrlBase = $(Get-GitHubConfiguration -Name "GitHubBaseUrl")
+
+    if (($Uri -match "^https?://(?:www.)?$gitHubUrlBase/([^/]+)/?([^/]+)?(?:/.*)?$") -or
+        ($Uri -match "^https?://api.$gitHubUrlBase/repos/([^/]+)/?([^/]+)?(?:/.*)?$"))
     {
         $components.ownerName = $Matches[1]
         if ($Matches.Count -gt 2)

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -151,9 +151,9 @@ function Invoke-GHRestMethod
     # we'll just always continue the existing one...
     $stopwatch.Start()
 
-    $gitHubApiUrl = "https://api.$(Get-GitHubConfiguration -Name "GitHubBaseUrl")"
+    $hostName = $(Get-GitHubConfiguration -Name "ApiHostName")
 
-    $url = "$gitHubApiUrl/$UriFragment"
+    $url = "https://api.$hostname/$UriFragment"
 
     # It's possible that we are directly calling the "nextLink" from a previous command which
     # provides the full URI.  If that's the case, we'll just use exactly what was provided to us.
@@ -734,10 +734,10 @@ function Split-GitHubUri
         repositoryName = [String]::Empty
     }
 
-    $gitHubUrlBase = $(Get-GitHubConfiguration -Name "GitHubBaseUrl")
+    $hostName = $(Get-GitHubConfiguration -Name "ApiHostName")
 
-    if (($Uri -match "^https?://(?:www.)?$gitHubUrlBase/([^/]+)/?([^/]+)?(?:/.*)?$") -or
-        ($Uri -match "^https?://api.$gitHubUrlBase/repos/([^/]+)/?([^/]+)?(?:/.*)?$"))
+    if (($Uri -match "^https?://(?:www.)?$hostName/([^/]+)/?([^/]+)?(?:/.*)?$") -or
+        ($Uri -match "^https?://api.$hostName/repos/([^/]+)/?([^/]+)?(?:/.*)?$"))
     {
         $components.ownerName = $Matches[1]
         if ($Matches.Count -gt 2)

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Set-GitHubConfiguration -DefaultRepositoryName PowerShellForGitHub
 There are more great configuration options available.  Just review the help for that command for
 the most up-to-date list!
 
+### GitHub Enterprise
+
+To set the configuration file to use a GitHub Enterprise server instead of GitHub.com, simply supply
+the `ApiHostName` parameter with the hostname of your GitHub Enterprise server.
+
+ ```powershell
+Set-GitHubConfiguration -ApiHostName "github.contoso.com"
+```
+
 ----------
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ the most up-to-date list!
 
 ### GitHub Enterprise
 
-To set the configuration file to use a GitHub Enterprise server instead of GitHub.com, simply supply
+To set the configuration to use a GitHub Enterprise server instead of GitHub.com, simply supply
 the `ApiHostName` parameter with the hostname of your GitHub Enterprise server.
 
  ```powershell


### PR DESCRIPTION
I think I ran the pester tests correctly, or at least they all came back green for me anyhow. Static analysis also came back empty.

This resolves #98 with the ability to supply a new configuration parameter, `GitHubBaseUrl`. It will default to `github.com`. GitHub Enterprise installs to a different URL and the API remains as `api.somegithub.com`, thus it's simple to hit that API on a different base URL.

I've been using a similar set of changes along with a few other quality of life ones in my organization over the past week as we prototyped out some tools around automating GitHub Enterprise. It performed admirably with these changes here.

Fixed a related typo in the documentation as well.