### PR TITLE
Update organization name in project from PowerShell to Microsoft

### DIFF
--- a/GitHubAssignees.ps1
+++ b/GitHubAssignees.ps1
@@ -33,9 +33,9 @@ function Get-GitHubAssignee
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubAsigneeList -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubAsigneeList -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Lists the available assignees for issues from the PowerShell\PowerShellForGitHub project.
+        Lists the available assignees for issues from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -119,9 +119,9 @@ function Test-GitHubAssignee
         [bool] If the assignee can be assigned to issues in the repository.
 
     .EXAMPLE
-        Test-GitHubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub -Assignee "LoginID123"
+        Test-GitHubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee "LoginID123"
 
-        Checks if a user has permission to be assigned to an issue from the PowerShell\PowerShellForGitHub project.
+        Checks if a user has permission to be assigned to an issue from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -220,9 +220,9 @@ function New-GithubAssignee
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        New-GithubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub -Assignee $assignee
+        New-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee $assignee
 
-        Lists the available assignees for issues from the PowerShell\PowerShellForGitHub project.
+        Lists the available assignees for issues from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -322,9 +322,9 @@ function Remove-GithubAssignee
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Remove-GithubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub -Assignee $assignees
+        Remove-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee $assignees
 
-        Lists the available assignees for issues from the PowerShell\PowerShellForGitHub project.
+        Lists the available assignees for issues from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/GitHubBranches.ps1
+++ b/GitHubBranches.ps1
@@ -42,7 +42,7 @@ function Get-GitHubRepositoryBranch
         [PSCustomObject[]] List of branches within the given repository.
 
     .EXAMPLE
-        Get-GitHubRepositoryBranch -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryBranch -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
         Gets all branches for the specified repository.
 

--- a/GitHubComments.ps1
+++ b/GitHubComments.ps1
@@ -56,9 +56,9 @@ function Get-GitHubComment
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubComment-OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubComment-OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Get the comments for the PowerShell\PowerShellForGitHub project.
+        Get the comments for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -236,9 +236,9 @@ function New-GitHubComment
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        New-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -Issue 1 -Body "Testing this API"
+        New-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 1 -Body "Testing this API"
 
-        Creates a new Github comment in an issue for the PowerShell\PowerShellForGitHub project.
+        Creates a new Github comment in an issue for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -347,9 +347,9 @@ function Set-GitHubComment
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Set-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -CommentID 1 -Body "Testing this API"
+        Set-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1 -Body "Testing this API"
 
-        Update an existing comment in an issue for the PowerShell\PowerShellForGitHub project.
+        Update an existing comment in an issue for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -447,9 +447,9 @@ function Remove-GitHubComment
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Remove-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -CommentID 1
+        Remove-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1
 
-        Deletes a Github comment from the PowerShell\PowerShellForGitHub project.
+        Deletes a Github comment from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/GitHubEvents.ps1
+++ b/GitHubEvents.ps1
@@ -39,9 +39,9 @@ function Get-GitHubEvent
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubEvent -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubEvent -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Get the events for the PowerShell\PowerShellForGitHub project.
+        Get the events for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -106,14 +106,14 @@ function Get-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State Open
+        Get-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -State Open
 
-        Gets all the currently open issues in the PowerShell\PowerShellForGitHub repository.
+        Gets all the currently open issues in the Microsoft\PowerShellForGitHub repository.
 
     .EXAMPLE
-        Get-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State All -Assignee Octocat
+        Get-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -State All -Assignee Octocat
 
-        Gets every issue in the PowerShell\PowerShellForGitHub repository that is assigned to Octocat.
+        Gets every issue in the Microsoft\PowerShellForGitHub repository that is assigned to Octocat.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -372,7 +372,7 @@ function Get-GitHubIssueTimeline
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubIssueTimeline -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 24
+        Get-GitHubIssueTimeline -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 24
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -480,7 +480,7 @@ function New-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        New-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Title 'Test Issue'
+        New-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Title 'Test Issue'
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -620,7 +620,7 @@ function Update-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Update-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -State Closed
+        Update-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -State Closed
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -745,7 +745,7 @@ function Lock-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Lock-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -Reason Spam
+        Lock-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 4 -Title 'Test Issue' -Reason Spam
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -855,7 +855,7 @@ function Unlock-GitHubIssue
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Unlock-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 4
+        Unlock-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 4
 #>
 [CmdletBinding(
     SupportsShouldProcess,

--- a/GitHubLabels.ps1
+++ b/GitHubLabels.ps1
@@ -46,14 +46,14 @@ function Get-GitHubLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubLabel -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Gets the information for every label from the PowerShell\PowerShellForGitHub project.
+        Gets the information for every label from the Microsoft\PowerShellForGitHub project.
 
     .EXAMPLE
-        Get-GitHubLabel -OwnerName Powershell -RepositoryName PowerShellForGitHub -LabelName TestLabel
+        Get-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -LabelName TestLabel
 
-        Gets the information for the label named "TestLabel" from the PowerShell\PowerShellForGitHub
+        Gets the information for the label named "TestLabel" from the Microsoft\PowerShellForGitHub
         project.
 #>
     [CmdletBinding(
@@ -198,7 +198,7 @@ function New-GitHubLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        New-GitHubLabel -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Name TestLabel -Color BBBBBB
+        New-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Color BBBBBB
 
         Creates a new, grey-colored label called "TestLabel" in the PowerShellForGitHub project.
 #>
@@ -312,7 +312,7 @@ function Remove-GitHubLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Remove-GitHubLabel -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Name TestLabel
+        Remove-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel
 
         Removes the label called "TestLabel" from the PowerShellForGitHub project.
 #>
@@ -417,7 +417,7 @@ function Update-GitHubLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Update-GitHubLabel -OwnerName Powershell -RepositoryName PowerShellForGitHub -Name TestLabel -NewName NewTestLabel -LabelColor BBBB00
+        Update-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -NewName NewTestLabel -LabelColor BBBB00
 
         Updates the existing label called TestLabel in the PowerShellForGitHub project to be called
         'NewTestLabel' and be colored yellow.
@@ -541,7 +541,7 @@ function Set-GitHubLabel
         removed (and thus unassigned from existing Issues) and then the new one created.
 
     .EXAMPLE
-        Set-GitHubLabel -OwnerName Powershell -RepositoryName PowerShellForGitHub -Label @(@{'name' = 'TestLabel'; 'color' = 'EEEEEE'}, @{'name' = 'critical'; 'color' = 'FF000000'; 'description' = 'Needs immediate attention'})
+        Set-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Label @(@{'name' = 'TestLabel'; 'color' = 'EEEEEE'}, @{'name' = 'critical'; 'color' = 'FF000000'; 'description' = 'Needs immediate attention'})
 
         Removes any labels not in this Label array, ensure the current assigned color and descriptions
         match what's in the array for the labels that do already exist, and then creates new labels
@@ -654,7 +654,7 @@ function Add-GitHubIssueLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Add-GitHubIssueLabel -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 1 -Name $labels
+        Add-GitHubIssueLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 1 -Name $labels
 
         Adds labels to an issue in the PowerShellForGitHub project.
 #>
@@ -755,7 +755,7 @@ function Set-GitHubIssueLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Set-GitHubIssueLabel -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 1 -LabelName $labels
+        Set-GitHubIssueLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 1 -LabelName $labels
 
         Replaces labels on an issue in the PowerShellForGitHub project.
 #>
@@ -857,7 +857,7 @@ function Remove-GitHubIssueLabel
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Remove-GitHubIssueLabel -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Name TestLabel -Issue 1
+        Remove-GitHubIssueLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Issue 1
 
         Removes the label called "TestLabel" from issue 1 in the PowerShellForGitHub project.
 #>

--- a/GitHubMilestones.ps1
+++ b/GitHubMilestones.ps1
@@ -45,12 +45,12 @@ function Get-GitHubMilestone
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub
-        Get the milestones for the PowerShell\PowerShellForGitHub project.
+        Get-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub
+        Get the milestones for the Microsoft\PowerShellForGitHub project.
 
     .EXAMPLE
         Get-GitHubMilestone -Uri 'https://github.com/PowerShell/PowerShellForGitHub' -Milestone 1
-        Get milestone number 1 for the PowerShell\PowerShellForGitHub project.
+        Get milestone number 1 for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -202,9 +202,9 @@ function New-GitHubMilestone
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        New-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Title "Testing this API"
+        New-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Title "Testing this API"
 
-        Creates a new Github milestone for the PowerShell\PowerShellForGitHub project.
+        Creates a new Github milestone for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -330,9 +330,9 @@ function Set-GitHubMilestone
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Set-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Milestone 1 -Title "Testing this API"
+        Set-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1 -Title "Testing this API"
 
-        Update an existing milestone for the PowerShell\PowerShellForGitHub project.
+        Update an existing milestone for the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -451,9 +451,9 @@ function Remove-GitHubMilestone
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Remove-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Milestone 1
+        Remove-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1
 
-        Deletes a Github milestone from the PowerShell\PowerShellForGitHub project.
+        Deletes a Github milestone from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/GitHubMiscellaneous.ps1
+++ b/GitHubMiscellaneous.ps1
@@ -218,9 +218,9 @@ function Get-GitHubLicense
         Gets the content of the mit license file
 
     .EXAMPLE
-        Get-GitHubLicense -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubLicense -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Gets the content of the license file for the PowerShell\PowerShellForGitHub repository.
+        Gets the content of the license file for the Microsoft\PowerShellForGitHub repository.
         It may be necessary to convert the content of the file.  Check the 'encoding' property of
         the result to know how 'content' is encoded.  As an example, to convert from Base64, do
         the following:
@@ -387,9 +387,9 @@ function Get-GitHubCodeOfConduct
         Gets the content of the 'Citizen Code of Conduct'
 
     .EXAMPLE
-        Get-GitHubCodeOfConduct -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubCodeOfConduct -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Gets the content of the Code of Coduct file for the PowerShell\PowerShellForGitHub repository
+        Gets the content of the Code of Coduct file for the Microsoft\PowerShellForGitHub repository
         if one is detected.
 
         It may be necessary to convert the content of the file.  Check the 'encoding' property of

--- a/GitHubPullRequests.ps1
+++ b/GitHubPullRequests.ps1
@@ -65,7 +65,7 @@ function Get-GitHubPullRequest
         $pullRequests = Get-GitHubPullRequest -Uri 'https://github.com/PowerShell/PowerShellForGitHub'
 
     .EXAMPLE
-        $pullRequests = Get-GitHubPullRequest -OwnerName PowerShell -RepositoryName PowerShellForGitHub -State Closed
+        $pullRequests = Get-GitHubPullRequest -OwnerName Microsoft -RepositoryName PowerShellForGitHub -State Closed
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -537,7 +537,7 @@ function Update-GitHubRepository
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Update-GitHubRepository -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Description 'The best way to automate your GitHub interactions'
+        Update-GitHubRepository -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Description 'The best way to automate your GitHub interactions'
 
     .EXAMPLE
         Update-GitHubRepository -Uri https://github.com/PowerShell/PowerShellForGitHub -Private:$false
@@ -661,7 +661,7 @@ function Get-GitHubRepositoryTopic
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubRepositoryTopic -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryTopic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
     .EXAMPLE
         Get-GitHubRepositoryTopic -Uri https://github.com/PowerShell/PowerShellForGitHub
@@ -753,7 +753,7 @@ function Set-GitHubRepositoryTopic
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Set-GitHubRepositoryTopic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Clear
+        Set-GitHubRepositoryTopic -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Clear
 
     .EXAMPLE
         Set-GitHubRepositoryTopic -Uri https://github.com/PowerShell/PowerShellForGitHub -Name ('octocat', 'powershell', 'github')
@@ -886,7 +886,7 @@ function Get-GitHubRepositoryContributor
         [PSCustomObject[]] List of contributors for the repository.
 
     .EXAMPLE
-        Get-GitHubRepositoryContributor -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryContributor -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
     .EXAMPLE
         Get-GitHubRepositoryContributor -Uri 'https://github.com/PowerShell/PowerShellForGitHub' -IncludeStatistics
@@ -985,7 +985,7 @@ function Get-GitHubRepositoryCollaborator
         [PSCustomObject[]] List of collaborators for the repository.
 
     .EXAMPLE
-        Get-GitHubRepositoryCollaborator -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryCollaborator -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
     .EXAMPLE
         Get-GitHubRepositoryCollaborator -Uri 'https://github.com/PowerShell/PowerShellForGitHub'
@@ -1073,7 +1073,7 @@ function Get-GitHubRepositoryLanguage
         for each language is the number of bytes of code written in that language.
 
     .EXAMPLE
-        Get-GitHubRepositoryLanguage -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryLanguage -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
     .EXAMPLE
         Get-GitHubRepositoryLanguage -Uri https://github.com/PowerShell/PowerShellForGitHub
@@ -1157,7 +1157,7 @@ function Get-GitHubRepositoryTag
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubRepositoryTag -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryTag -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
     .EXAMPLE
         Get-GitHubRepositoryTag -Uri https://github.com/PowerShell/PowerShellForGitHub
@@ -1248,7 +1248,7 @@ function Move-GitHubRepositoryOwnership
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Move-GitHubRepositoryOwnership -OwnerName PowerShell -RepositoryName PowerShellForGitHub -NewOwnerName OctoCat
+        Move-GitHubRepositoryOwnership -OwnerName Microsoft -RepositoryName PowerShellForGitHub -NewOwnerName OctoCat
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/GitHubRepositoryForks.ps1
+++ b/GitHubRepositoryForks.ps1
@@ -39,9 +39,9 @@ function Get-GitHubRepositoryFork
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Gets all of the forks for the PowerShell\PowerShellForGitHub repository.
+        Gets all of the forks for the Microsoft\PowerShellForGitHub repository.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -134,12 +134,12 @@ function New-GitHubRepositoryFork
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        New-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        New-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
         Creates a fork of this repository under the current authenticated user's account.
 
     .EXAMPLE
-        New-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -OrganizationName OctoLabs
+        New-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub -OrganizationName OctoLabs
 
         Creates a fork of this repository under the OctoLabs organization.
 #>

--- a/GitHubRepositoryTraffic.ps1
+++ b/GitHubRepositoryTraffic.ps1
@@ -36,9 +36,9 @@ function Get-GitHubReferrerTraffic
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubReferrerTraffic -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubReferrerTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Get the top 10 referrers over the last 14 days from the PowerShell\PowerShellForGitHub project.
+        Get the top 10 referrers over the last 14 days from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -120,9 +120,9 @@ function Get-GitHubPathTraffic
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubPathTraffic -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubPathTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Get the top 10 popular contents over the last 14 days from the PowerShell\PowerShellForGitHub project.
+        Get the top 10 popular contents over the last 14 days from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -208,9 +208,9 @@ function Get-GitHubViewTraffic
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubViewTraffic -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubViewTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Get the total number of views and breakdown per day or week for the last 14 days from the PowerShell\PowerShellForGitHub project.
+        Get the total number of views and breakdown per day or week for the last 14 days from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -300,9 +300,9 @@ function Get-GitHubCloneTraffic
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubCloneTraffic -OwnerName Powershell -RepositoryName PowerShellForGitHub
+        Get-GitHubCloneTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
-        Get the total number of clones and breakdown per day or week for the last 14 days from the PowerShell\PowerShellForGitHub project.
+        Get the total number of clones and breakdown per day or week for the last 14 days from the Microsoft\PowerShellForGitHub project.
 #>
     [CmdletBinding(
         SupportsShouldProcess,

--- a/Tests/GitHubRepositoryForks.tests.ps1
+++ b/Tests/GitHubRepositoryForks.tests.ps1
@@ -79,11 +79,11 @@ try
     Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
 
     Describe 'Creating a new fork for user' {
-        $originalForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        $originalForks = Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
         Context 'When a new fork is created' {
-            $repo = New-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
-            $newForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Sort Newest
+            $repo = New-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
+            $newForks = Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Sort Newest
 
             It 'Should have one more fork than before' {
                 (@($newForks).Count - @($originalForks).Count) | Should be 1
@@ -98,11 +98,11 @@ try
     }
 
     Describe 'Creating a new fork for an org' {
-        $originalForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+        $originalForks = Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
         Context 'When a new fork is created' {
-            $repo = New-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -OrganizationName $script:organizationName
-            $newForks = Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Sort Newest
+            $repo = New-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub -OrganizationName $script:organizationName
+            $newForks = Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Sort Newest
 
             It 'Should have one more fork than before' {
                 (@($newForks).Count - @($originalForks).Count) | Should be 1

--- a/USAGE.md
+++ b/USAGE.md
@@ -193,8 +193,8 @@ $issueCounts | Sort-Object -Property Count -Descending
 #### Querying Pull Requests
 
 ```powershell
-# Getting all of the pull requests from the PowerShell\PowerShellForGitHub repository
-$issues = Get-GitHubIssue -OwnerName PowerShell -RepositoryName 'PowerShellForGitHub'
+# Getting all of the pull requests from the Microsoft\PowerShellForGitHub repository
+$issues = Get-GitHubIssue -OwnerName Microsoft -RepositoryName 'PowerShellForGitHub'
 ```
 
 ```powershell
@@ -282,27 +282,27 @@ $teamMembers = Get-GitHubTeamMembers -OrganizationName 'OrganizationName' -TeamN
 
 #### Getting Labels for a Repository
 ```powershell
-$labels = Get-GitHubLabel -OwnerName Powershell -RepositoryName DesiredStateConfiguration
+$labels = Get-GitHubLabel -OwnerName PowerShell -RepositoryName DesiredStateConfiguration
 ```
 
 #### Getting Labels for an Issue
 ```powershell
-$labels = Get-GitHubLabel -OwnerName Powershell -RepositoryName DesiredStateConfiguration -Issue 1
+$labels = Get-GitHubLabel -OwnerName PowerShell -RepositoryName DesiredStateConfiguration -Issue 1
 ```
 
 #### Getting Labels for a Milestone
 ```powershell
-$labels = Get-GitHubLabel -OwnerName Powershell -RepositoryName DesiredStateConfiguration -Milestone 1
+$labels = Get-GitHubLabel -OwnerName PowerShell -RepositoryName DesiredStateConfiguration -Milestone 1
 ```
 
 #### Adding a New Label to a Repository
 ```powershell
-New-GitHubLabel -OwnerName Powershell -RepositoryName DesiredStateConfiguration -Name TestLabel -Color BBBBBB
+New-GitHubLabel -OwnerName PowerShell -RepositoryName DesiredStateConfiguration -Name TestLabel -Color BBBBBB
 ```
 
 #### Removing a Label From a Repository
 ```powershell
-Remove-GitHubLabel -OwnerName Powershell -RepositoryName desiredstateconfiguration -Name TestLabel
+Remove-GitHubLabel -OwnerName PowerShell -RepositoryName desiredstateconfiguration -Name TestLabel
 ```
 
 #### Adding Labels to an Issue
@@ -313,18 +313,18 @@ Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryNam
 
 #### Removing a Label From an Issue
 ```powershell
-Remove-GitHubIssueLabel -OwnerName Powershell -RepositoryName desiredstateconfiguration -Name TestLabel -Issue 1
+Remove-GitHubIssueLabel -OwnerName Microsoft -RepositoryName desiredstateconfiguration -Name TestLabel -Issue 1
 ```
 
 #### Updating a Label With a New Name and Color
 ```powershell
-Update-GitHubLabel -OwnerName Powershell -RepositoryName DesiredStateConfiguration -Name TestLabel -NewName NewTestLabel -Color BBBB00
+Update-GitHubLabel -OwnerName Microsoft -RepositoryName DesiredStateConfiguration -Name TestLabel -NewName NewTestLabel -Color BBBB00
 ```
 
 #### Bulk Updating Labels in a Repository
 ```powershell
 $labels = @( @{ 'name' = 'Label1'; 'color' = 'BBBB00'; 'description' = 'My label description' }, @{ 'name' = 'Label2'; 'color' = 'FF00000' })
-Set-GitHubLabel -OwnerName Powershell -RepositoryName DesiredStateConfiguration -Label $labels
+Set-GitHubLabel -OwnerName PowerShell -RepositoryName DesiredStateConfiguration -Label $labels
 ```
 
 ----------
@@ -358,12 +358,12 @@ Get-GitHubUser
 
 #### Get all the forks for a repository
 ```powershell
-Get-GitHubRepositoryFork -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 ```
 
 #### Create a new fork
 ```powershell
-New-GitHubRepositoryForm -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+New-GitHubRepositoryForm -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 ```
 
 ----------
@@ -372,22 +372,22 @@ New-GitHubRepositoryForm -OwnerName PowerShell -RepositoryName PowerShellForGitH
 
 #### Get the referrer traffic for a repository
 ```powershell
-Get-GitHubReferrerTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+Get-GitHubReferrerTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 ```
 
 #### Get the popular content for a repository
 ```powershell
-Get-GitHubPathTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub
+Get-GitHubPathTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 ```
 
 #### Get the number of views for a repository
 ```powershell
-Get-GitHubViewTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Per Week
+Get-GitHubViewTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Per Week
 ```
 
 #### Get the number of clones for a repository
 ```powershell
-Get-GitHubCloneTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Per Day
+Get-GitHubCloneTraffic -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Per Day
 ```
 
 ----------
@@ -396,22 +396,22 @@ Get-GitHubCloneTraffic -OwnerName PowerShell -RepositoryName PowerShellForGitHub
 
 #### Get assignees
 ```powershell
-Get-GitHubAsignee -OwnerName Powershell -RepositoryName PowerShellForGitHub
+Get-GitHubAsignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 ```
 
 #### Check assignee permission
 ```powershell
-$HasPermission = Test-GitHubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub -Assignee "LoginID123"
+$HasPermission = Test-GitHubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee "LoginID123"
 ```
 
 #### Add assignee to an issue
 ```powershell
-New-GithubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub -Assignees $assignees -Issue 1
+New-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignees $assignees -Issue 1
 ```
 
 #### Remove assignee from an issue
 ```powershell
-Remove-GithubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub -Assignees $assignees -Issue 1
+Remove-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignees $assignees -Issue 1
 ```
 
 ----------
@@ -420,32 +420,32 @@ Remove-GithubAssignee -OwnerName Powershell -RepositoryName PowerShellForGitHub 
 
 #### Get comments from an issue
 ```powershell
-Get-GitHubIssueComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -Issue 1
+Get-GitHubIssueComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 1
 ```
 
 #### Get comments from a repository
 ```powershell
-Get-GitHubRepositoryComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -Sort Created -Direction Ascending -Since '2011-04-14T16:00:49Z'
+Get-GitHubRepositoryComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Sort Created -Direction Ascending -Since '2011-04-14T16:00:49Z'
 ```
 
 #### Get a single comment
 ```powershell
-Get-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -CommentID 1
+Get-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1
 ```
 
 #### Adding a new comment to an issue
 ```powershell
-New-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -Issue 1 -Body "Testing this API"
+New-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 1 -Body "Testing this API"
 ```
 
 #### Editing an existing comment
 ```powershell
-Set-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -CommentID 1 -Body "Testing this API"
+Set-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1 -Body "Testing this API"
 ```
 
 #### Removing a comment
 ```powershell
-Remove-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -CommentID 1
+Remove-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1
 ```
 
 ----------
@@ -454,28 +454,28 @@ Remove-GitHubComment -OwnerName Powershell -RepositoryName PowerShellForGitHub -
 
 #### Get milestones from a repository
 ```powershell
-Get-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Sort DueOn -Direction Ascending -DueOn '2011-04-14T16:00:49Z'
+Get-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Sort DueOn -Direction Ascending -DueOn '2011-04-14T16:00:49Z'
 ```
 
 #### Get a single milestone
 ```powershell
-Get-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Milestone 1
+Get-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1
 ```
 
 #### Assign an existing issue to a new milestone
 ```powershell
-New-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Title "Testing this API"
-Update-GitHubIssue -OwnerName PowerShell -RepositoryName PowerShellForGitHub -Issue 2 -Milestone 1
+New-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Title "Testing this API"
+Update-GitHubIssue -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 2 -Milestone 1
 ```
 
 #### Editing an existing milestone
 ```powershell
-Set-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Milestone 1 -Title "Testing this API edited"
+Set-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1 -Title "Testing this API edited"
 ```
 
 #### Removing a milestone
 ```powershell
-Remove-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub -Milestone 1
+Remove-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1
 ```
 
 ----------
@@ -484,15 +484,15 @@ Remove-GitHubMilestone -OwnerName Powershell -RepositoryName PowerShellForGitHub
 
 #### Get events from a repository
 ```powershell
-Get-GitHubEvent -OwnerName Powershell -RepositoryName PowerShellForGitHub
+Get-GitHubEvent -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 ```
 
 #### Get events from an issue
 ```powershell
-Get-GitHubEvent -OwnerName Powershell -RepositoryName PowerShellForGitHub -Issue 1
+Get-GitHubEvent -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Issue 1
 ```
 
 #### Get a single event
 ```powershell
-Get-GitHubEvent -OwnerName Powershell -RepositoryName PowerShellForGitHub -EventID 1
+Get-GitHubEvent -OwnerName Microsoft -RepositoryName PowerShellForGitHub -EventID 1
 ```


### PR DESCRIPTION
This project has been transferred from the PowerShell organization to the
Microsoft organization.  This update fixes any references to the organization
name.