### PR TITLE
Refactor common Pester test infrastructure

### DIFF
--- a/Tests/Common.ps1
+++ b/Tests/Common.ps1
@@ -1,0 +1,81 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Caches if the tests are actively configured with an access token.
+$script:accessTokenConfigured = $false
+
+# The path to a file storing the contents of the user's config file before tests got underway
+$script:originalConfigFile = $null
+
+function Initialize-CommonTestSetup
+{
+<#
+    .SYNOPSIS
+        Configures the tests to run with the authentication information stored in the project's
+        Azure DevOps pipeline (if that information exists in the environment).
+
+    .DESCRIPTION
+        Configures the tests to run with the authentication information stored in the project's
+        Azure DevOps pipeline (if that information exists in the environment).
+
+        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
+
+    .NOTES
+        Internal-only helper method.
+
+        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
+        which can only be applied to functions.
+
+        This method is invoked immediately after the declaration.
+#>
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
+    param()
+
+    $moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+    . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Config\Settings.ps1')
+    Import-Module -Name (Join-Path -Path $moduleRootPath -ChildPath 'PowerShellForGitHub.psd1') -Force
+
+    if ([string]::IsNullOrEmpty($env:avAccessToken))
+    {
+        $message = @(
+            'The tests are using the configuration settings defined in Tests\Config\Settings.ps1.',
+            'If you haven''t locally modified those values, your tests are going to fail since you',
+            'don''t have access to the default accounts referenced.  If that is the case, you should',
+            'cancel the existing tests, modify the values to ones you have access to, call',
+            'Set-GitHubAuthentication to cache your AccessToken, and then try running the tests again.')
+        Write-Warning -Message ($message -join [Environment]::NewLine)
+    }
+    else
+    {
+        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
+        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
+        Set-GitHubAuthentication -Credential $cred
+
+        $script:ownerName = $env:avOwnerName
+        $script:organizationName = $env:avOrganizationName
+
+        Write-Warning -Message 'This run is being executed in the AppVeyor environment.'
+    }
+
+    $script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
+    if (-not $script:accessTokenConfigured)
+    {
+        $message = @(
+            'GitHub API Token not defined.  Most of these tests are going to fail since they require authentication.',
+            '403 errors may also start to occur due to the GitHub hourly limit for unauthenticated queries.')
+        Write-Warning -Message ($message -join [Environment]::NewLine)
+    }
+
+    # Backup the user's configuration before we begin, and ensure we're at a pure state before running
+    # the tests.  We'll restore it at the end.
+    $script:originalConfigFile = New-TemporaryFile
+
+    Backup-GitHubConfiguration -Path $script:originalConfigFile
+    Set-GitHubConfiguration -DisableTelemetry # Avoid the telemetry event from calling Reset-GitHubConfiguration
+    Reset-GitHubConfiguration
+    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
+    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
+}
+
+Initialize-CommonTestSetup

--- a/Tests/GitHubAnalytics.tests.ps1
+++ b/Tests/GitHubAnalytics.tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubAnalytics.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     Describe 'Obtaining issues for repository' {
         $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
 
@@ -378,6 +312,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubAssignees.tests.ps1
+++ b/Tests/GitHubAssignees.tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubAssignees.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can happen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
     $issue = New-GitHubIssue -Uri $repo.svn_url -Title "Test issue"
 
@@ -131,6 +65,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubComments.tests.ps1
+++ b/Tests/GitHubComments.tests.ps1
@@ -6,79 +6,13 @@
    Tests for GitHubComments.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     # Define Script-scoped, readonly, hidden variables.
-
     @{
         defaultIssueTitle = "Test Title"
         defaultCommentBody = "This is a test body."
@@ -157,6 +91,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubCore.Tests.ps1
+++ b/Tests/GitHubCore.Tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubCore.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     Describe 'Testing ConvertTo-SmarterObject behavior' {
         InModuleScope PowerShellForGitHub {
             $jsonConversionDepth = 20
@@ -264,6 +198,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubEvents.tests.ps1
+++ b/Tests/GitHubEvents.tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubEvents.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     if ($accessTokenConfigured)
     {
         Describe 'Getting events from repository' {
@@ -152,9 +86,12 @@ try
         }
     }
 }
-catch
+finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }
-

--- a/Tests/GitHubLabels.tests.ps1
+++ b/Tests/GitHubLabels.tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubLabels.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     $defaultLabels = @(
         @{
             'name' = 'pri:lowest'
@@ -391,6 +325,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubMilestones.tests.ps1
+++ b/Tests/GitHubMilestones.tests.ps1
@@ -6,80 +6,13 @@
    Tests for GitHubMilestones.ps1 module
 #>
 
-$root = Split-Path -Parent $PSScriptRoot
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can happen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     # Define Script-scoped, readonly, hidden variables.
-
     @{
         defaultIssueTitle = "This is a test issue."
         defaultMilestoneTitle1 = "This is a test milestone title #1."
@@ -175,6 +108,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubRepositoryForks.tests.ps1
+++ b/Tests/GitHubRepositoryForks.tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubRepositoryForks.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     Describe 'Creating a new fork for user' {
         $originalForks = Get-GitHubRepositoryFork -OwnerName Microsoft -RepositoryName PowerShellForGitHub
 
@@ -118,6 +52,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }

--- a/Tests/GitHubRepositoryTraffic.tests.ps1
+++ b/Tests/GitHubRepositoryTraffic.tests.ps1
@@ -6,78 +6,12 @@
    Tests for GitHubRepositoryTraffic.ps1 module
 #>
 
-[String] $root = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-. (Join-Path -Path $root -ChildPath 'Tests\Config\Settings.ps1')
-Import-Module -Name $root -Force
-
-function Initialize-AppVeyor
-{
-<#
-    .SYNOPSIS
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-    .DESCRIPTION
-        Configures the tests to run with the authentication information stored in AppVeyor
-        (if that information exists in the environment).
-
-        The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
-
-    .NOTES
-        Internal-only helper method.
-
-        The only reason this exists is so that we can leverage CodeAnalysis.SuppressMessageAttribute,
-        which can only be applied to functions.
-
-        We call this immediately after the declaration so that AppVeyor initialization can heppen
-        (if applicable).
-
-#>
-    [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
-    param()
-
-    if ($env:AppVeyor)
-    {
-        $secureString = $env:avAccessToken | ConvertTo-SecureString -AsPlainText -Force
-        $cred = New-Object System.Management.Automation.PSCredential "<username is ignored>", $secureString
-        Set-GitHubAuthentication -Credential $cred
-
-        $script:ownerName = $env:avOwnerName
-        $script:organizationName = $env:avOrganizationName
-
-        $message = @(
-            'This run is executed in the AppVeyor environment.',
-            'The GitHub Api Token won''t be decrypted in PR runs causing some tests to fail.',
-            '403 errors possible due to GitHub hourly limit for unauthenticated queries.',
-            'Use Set-GitHubAuthentication manually. modify the values in Tests\Config\Settings.ps1,',
-            'and run tests on your machine first.')
-        Write-Warning -Message ($message -join [Environment]::NewLine)
-    }
-}
-
-Initialize-AppVeyor
-
-$script:accessTokenConfigured = Test-GitHubAuthenticationConfigured
-if (-not $script:accessTokenConfigured)
-{
-    $message = @(
-        'GitHub API Token not defined, some of the tests will be skipped.',
-        '403 errors possible due to GitHub hourly limit for unauthenticated queries.')
-    Write-Warning -Message ($message -join [Environment]::NewLine)
-}
-
-# Backup the user's configuration before we begin, and ensure we're at a pure state before running
-# the tests.  We'll restore it at the end.
-$configFile = New-TemporaryFile
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
 {
-    Backup-GitHubConfiguration -Path $configFile
-    Reset-GitHubConfiguration
-    Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
-    Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
-
     Describe 'Getting the referrer list' {
         $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
 
@@ -136,6 +70,10 @@ try
 }
 finally
 {
-    # Restore the user's configuration to its pre-test state
-    Restore-GitHubConfiguration -Path $configFile
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
 }


### PR DESCRIPTION
The Pester test files contained _a lot_ of duplicated test
setup/configuration.  This update factors all of that out
to Test/Common.ps1 so that _just about_ the entire content
of a Pester test file can be unique to the code being tested.