### PR TITLE
Add diagnostic data dll names to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Tests/Config/Settings.ps1
+Microsoft.ApplicationInsights.dll
+Microsoft.Diagnostics.Tracing.EventSource.dll
+Microsoft.Threading.Tasks.dll


### PR DESCRIPTION
These dll's are used for reporting diagnostic data and users can
optionally store them in the module's directory to avoid downloading
them on demand (or they can use Set-GitHubConfiguration -AssemblyPath
to specify an alternate location).

For users that opt to put the dll's in the module directory and are using
the module from a git enlistment, this will ignore those files.

This should be temporary and should be able to be undone once #104 is resolved.