### PR TITLE
Fix hostname support for Enterprise installations of GitHub

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "editor.formatOnSave": false,
+    "editor.formatOnType": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "editor.formatOnSave": false,
-    "editor.formatOnType": false
-}

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -2,20 +2,20 @@
 # Licensed under the MIT License.
 
 @{
-    defaultAcceptHeader = 'application/vnd.github.v3+json'
-    mediaTypeVersion = 'v3'
+    defaultAcceptHeader  = 'application/vnd.github.v3+json'
+    mediaTypeVersion     = 'v3'
     squirrelAcceptHeader = 'application/vnd.github.squirrel-girl-preview'
     symmetraAcceptHeader = 'application/vnd.github.symmetra-preview+json'
 
- }.GetEnumerator() | ForEach-Object {
-     Set-Variable -Scope Script -Option ReadOnly -Name $_.Key -Value $_.Value
- }
+}.GetEnumerator() | ForEach-Object {
+    Set-Variable -Scope Script -Option ReadOnly -Name $_.Key -Value $_.Value
+}
 
 Set-Variable -Scope Script -Option ReadOnly -Name ValidBodyContainingRequestMethods -Value ('Post', 'Patch', 'Put', 'Delete')
 
 function Invoke-GHRestMethod
 {
-<#
+    <#
     .SYNOPSIS
         A wrapper around Invoke-WebRequest that understands the Store API.
 
@@ -116,7 +116,7 @@ function Invoke-GHRestMethod
 
         [string] $TelemetryEventName = $null,
 
-        [hashtable] $TelemetryProperties = @{},
+        [hashtable] $TelemetryProperties = @{ },
 
         [string] $TelemetryExceptionBucket = $null,
 
@@ -137,7 +137,7 @@ function Invoke-GHRestMethod
     # Telemetry-related
     $stopwatch = New-Object -TypeName System.Diagnostics.Stopwatch
     $localTelemetryProperties = @{
-        'UriFragment' = $UriFragment
+        'UriFragment'       = $UriFragment
         'WaitForCompletion' = ($WaitForCompletion -eq $true)
     }
     $TelemetryProperties.Keys | ForEach-Object { $localTelemetryProperties[$_] = $TelemetryProperties[$_] }
@@ -153,7 +153,14 @@ function Invoke-GHRestMethod
 
     $hostName = $(Get-GitHubConfiguration -Name "ApiHostName")
 
-    $url = "https://api.$hostName/$UriFragment"
+    if ($hostName -eq "github.com")
+    {
+        $url = "https://api.$hostName/$UriFragment"
+    }
+    else
+    {
+        $url = "https://$hostName/api/v3/$UriFragment"
+    }
 
     # It's possible that we are directly calling the "nextLink" from a previous command which
     # provides the full URI.  If that's the case, we'll just use exactly what was provided to us.
@@ -163,7 +170,7 @@ function Invoke-GHRestMethod
     }
 
     $headers = @{
-        'Accept' = $AcceptHeader
+        'Accept'     = $AcceptHeader
         'User-Agent' = 'PowerShellForGitHub'
     }
 
@@ -188,7 +195,7 @@ function Invoke-GHRestMethod
         {
             if ($PSCmdlet.ShouldProcess($url, "Invoke-WebRequest"))
             {
-                $params = @{}
+                $params = @{ }
                 $params.Add("Uri", $url)
                 $params.Add("Method", $Method)
                 $params.Add("Headers", $headers)
@@ -207,7 +214,7 @@ function Invoke-GHRestMethod
                     }
                 }
 
-                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
+                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                 $result = Invoke-WebRequest @params
                 if ($Method -eq 'Delete')
                 {
@@ -231,7 +238,7 @@ function Invoke-GHRestMethod
                     . (Join-Path -Path $ScriptRootPath -ChildPath 'Helpers.ps1')
                     . (Join-Path -Path $ScriptRootPath -ChildPath 'GitHubConfiguration.ps1')
 
-                    $params = @{}
+                    $params = @{ }
                     $params.Add("Uri", $Url)
                     $params.Add("Method", $Method)
                     $params.Add("Headers", $Headers)
@@ -252,7 +259,7 @@ function Invoke-GHRestMethod
 
                     try
                     {
-                        [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
+                        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
                         Invoke-WebRequest @params
                     }
                     catch [System.Net.WebException]
@@ -263,7 +270,7 @@ function Invoke-GHRestMethod
                         # information that we actually care about *now*, and then we'll throw our own exception
                         # that is just a JSON object with the data that we'll later extract for processing in
                         # the main catch.
-                        $ex = @{}
+                        $ex = @{ }
                         $ex.Message = $_.Exception.Message
                         $ex.StatusCode = $_.Exception.Response.StatusCode
                         $ex.StatusDescription = $_.Exception.Response.StatusDescription
@@ -374,18 +381,18 @@ function Invoke-GHRestMethod
         if ($ExtendedResult)
         {
             $finalResultEx = @{
-                'result' = $finalResult
-                'statusCode' = $result.StatusCode
-                'requestId' = $result.Headers['X-GitHub-Request-Id']
-                'nextLink' = $nextLink
-                'link' = $result.Headers['Link']
-                'lastModified' = $result.Headers['Last-Modified']
-                'ifNoneMatch' = $result.Headers['If-None-Match']
-                'ifModifiedSince' = $result.Headers['If-Modified-Since']
-                'eTag' = $result.Headers['ETag']
-                'rateLimit' = $result.Headers['X-RateLimit-Limit']
+                'result'             = $finalResult
+                'statusCode'         = $result.StatusCode
+                'requestId'          = $result.Headers['X-GitHub-Request-Id']
+                'nextLink'           = $nextLink
+                'link'               = $result.Headers['Link']
+                'lastModified'       = $result.Headers['Last-Modified']
+                'ifNoneMatch'        = $result.Headers['If-None-Match']
+                'ifModifiedSince'    = $result.Headers['If-Modified-Since']
+                'eTag'               = $result.Headers['ETag']
+                'rateLimit'          = $result.Headers['X-RateLimit-Limit']
                 'rateLimitRemaining' = $result.Headers['X-RateLimit-Remaining']
-                'rateLimitReset' = $result.Headers['X-RateLimit-Reset']
+                'rateLimitReset'     = $result.Headers['X-RateLimit-Reset']
             }
 
             return ([PSCustomObject] $finalResultEx)
@@ -523,7 +530,7 @@ function Invoke-GHRestMethod
 
 function Invoke-GHRestMethodMultipleResult
 {
-<#
+    <#
     .SYNOPSIS
         A special-case wrapper around Invoke-GHRestMethod that understands GET URI's
         which support the 'top' and 'max' parameters.
@@ -598,7 +605,7 @@ function Invoke-GHRestMethodMultipleResult
         shown to the user until a response is returned from the REST request.
 #>
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
     [OutputType([Object[]])]
     param(
         [Parameter(Mandatory)]
@@ -613,7 +620,7 @@ function Invoke-GHRestMethodMultipleResult
 
         [string] $TelemetryEventName = $null,
 
-        [hashtable] $TelemetryProperties = @{},
+        [hashtable] $TelemetryProperties = @{ },
 
         [string] $TelemetryExceptionBucket = $null,
 
@@ -638,17 +645,18 @@ function Invoke-GHRestMethodMultipleResult
 
     try
     {
-        do {
+        do
+        {
             $params = @{
-                'UriFragment' = $nextLink
-                'Method' = 'Get'
-                'Description' = $currentDescription
-                'AcceptHeader' = $AcceptHeader
-                'ExtendedResult' = $true
-                'AccessToken' = $AccessToken
-                'TelemetryProperties' = $telemetryProperties
+                'UriFragment'              = $nextLink
+                'Method'                   = 'Get'
+                'Description'              = $currentDescription
+                'AcceptHeader'             = $AcceptHeader
+                'ExtendedResult'           = $true
+                'AccessToken'              = $AccessToken
+                'TelemetryProperties'      = $telemetryProperties
                 'TelemetryExceptionBucket' = $errorBucket
-                'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
+                'NoStatus'                 = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
             }
 
             $result = Invoke-GHRestMethod @params
@@ -677,7 +685,7 @@ function Invoke-GHRestMethodMultipleResult
 
 function Split-GitHubUri
 {
-<#
+    <#
     .SYNOPSIS
         Extracts the relevant elements of a GitHub repository Uri and returns the requested element.
 
@@ -715,22 +723,22 @@ function Split-GitHubUri
 
         PowerShell
 #>
-    [CmdletBinding(DefaultParametersetName='RepositoryName')]
+    [CmdletBinding(DefaultParametersetName = 'RepositoryName')]
     param
     (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string] $Uri,
 
-        [Parameter(ParameterSetName='OwnerName')]
+        [Parameter(ParameterSetName = 'OwnerName')]
         [switch] $OwnerName,
 
-        [Parameter(ParameterSetName='RepositoryName')]
+        [Parameter(ParameterSetName = 'RepositoryName')]
         [switch] $RepositoryName
     )
 
     $components = @{
-        ownerName = [String]::Empty
+        ownerName      = [String]::Empty
         repositoryName = [String]::Empty
     }
 
@@ -758,7 +766,7 @@ function Split-GitHubUri
 
 function Resolve-RepositoryElements
 {
-<#
+    <#
     .SYNOPSIS
         Determines the OwnerName and RepositoryName from the possible parameter values.
 
@@ -783,8 +791,8 @@ function Resolve-RepositoryElements
         [PSCutomObject] - The OwnerName and RepositoryName elements to be used
 #>
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="This was the most accurate name that I could come up with.  Internal only anyway.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "This was the most accurate name that I could come up with.  Internal only anyway.")]
     param
     (
         $BoundParameters = (Get-Variable -Name PSBoundParameters -Scope 1 -ValueOnly),
@@ -793,10 +801,10 @@ function Resolve-RepositoryElements
     )
 
     $validate = -not $DisableValidation
-    $elements = @{}
+    $elements = @{ }
 
     if ($BoundParameters.ContainsKey('Uri') -and
-       ($BoundParameters.ContainsKey('OwnerName') -or $BoundParameters.ContainsKey('RepositoryName')))
+        ($BoundParameters.ContainsKey('OwnerName') -or $BoundParameters.ContainsKey('RepositoryName')))
     {
         $message = "Cannot specify a Uri AND individual OwnerName/RepositoryName.  Please choose one or the other."
         Write-Log -Message $message -Level Error
@@ -852,7 +860,7 @@ $script:datePropertyNames = @(
 
 filter ConvertTo-SmarterObject
 {
-<#
+    <#
     .SYNOPSIS
         Updates the properties of the input object to be object themselves when the conversion
         is possible.
@@ -885,8 +893,8 @@ filter ConvertTo-SmarterObject
     if ($InputObject -is [System.Collections.IList])
     {
         $InputObject |
-            ConvertTo-SmarterObject |
-            Write-Output
+        ConvertTo-SmarterObject |
+        Write-Output
     }
     elseif ($InputObject -is [PSCustomObject])
     {
@@ -929,7 +937,7 @@ filter ConvertTo-SmarterObject
 
 function Get-MediaAcceptHeader
 {
-<#
+    <#
     .DESCRIPTION
         Returns a formatted AcceptHeader based on the requested MediaType
 
@@ -966,4 +974,3 @@ function Get-MediaAcceptHeader
 
     return ($acceptHeaders -join ',')
 }
-

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -153,7 +153,7 @@ function Invoke-GHRestMethod
 
     $hostName = $(Get-GitHubConfiguration -Name "ApiHostName")
 
-    if ($hostName -eq "github.com")
+    if ($hostName -eq 'github.com')
     {
         $url = "https://api.$hostName/$UriFragment"
     }

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -2,20 +2,20 @@
 # Licensed under the MIT License.
 
 @{
-    defaultAcceptHeader  = 'application/vnd.github.v3+json'
-    mediaTypeVersion     = 'v3'
+    defaultAcceptHeader = 'application/vnd.github.v3+json'
+    mediaTypeVersion = 'v3'
     squirrelAcceptHeader = 'application/vnd.github.squirrel-girl-preview'
     symmetraAcceptHeader = 'application/vnd.github.symmetra-preview+json'
 
-}.GetEnumerator() | ForEach-Object {
-    Set-Variable -Scope Script -Option ReadOnly -Name $_.Key -Value $_.Value
-}
+ }.GetEnumerator() | ForEach-Object {
+     Set-Variable -Scope Script -Option ReadOnly -Name $_.Key -Value $_.Value
+ }
 
 Set-Variable -Scope Script -Option ReadOnly -Name ValidBodyContainingRequestMethods -Value ('Post', 'Patch', 'Put', 'Delete')
 
 function Invoke-GHRestMethod
 {
-    <#
+<#
     .SYNOPSIS
         A wrapper around Invoke-WebRequest that understands the Store API.
 
@@ -116,7 +116,7 @@ function Invoke-GHRestMethod
 
         [string] $TelemetryEventName = $null,
 
-        [hashtable] $TelemetryProperties = @{ },
+        [hashtable] $TelemetryProperties = @{},
 
         [string] $TelemetryExceptionBucket = $null,
 
@@ -137,7 +137,7 @@ function Invoke-GHRestMethod
     # Telemetry-related
     $stopwatch = New-Object -TypeName System.Diagnostics.Stopwatch
     $localTelemetryProperties = @{
-        'UriFragment'       = $UriFragment
+        'UriFragment' = $UriFragment
         'WaitForCompletion' = ($WaitForCompletion -eq $true)
     }
     $TelemetryProperties.Keys | ForEach-Object { $localTelemetryProperties[$_] = $TelemetryProperties[$_] }
@@ -170,7 +170,7 @@ function Invoke-GHRestMethod
     }
 
     $headers = @{
-        'Accept'     = $AcceptHeader
+        'Accept' = $AcceptHeader
         'User-Agent' = 'PowerShellForGitHub'
     }
 
@@ -195,7 +195,7 @@ function Invoke-GHRestMethod
         {
             if ($PSCmdlet.ShouldProcess($url, "Invoke-WebRequest"))
             {
-                $params = @{ }
+                $params = @{}
                 $params.Add("Uri", $url)
                 $params.Add("Method", $Method)
                 $params.Add("Headers", $headers)
@@ -214,7 +214,7 @@ function Invoke-GHRestMethod
                     }
                 }
 
-                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+                [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                 $result = Invoke-WebRequest @params
                 if ($Method -eq 'Delete')
                 {
@@ -238,7 +238,7 @@ function Invoke-GHRestMethod
                     . (Join-Path -Path $ScriptRootPath -ChildPath 'Helpers.ps1')
                     . (Join-Path -Path $ScriptRootPath -ChildPath 'GitHubConfiguration.ps1')
 
-                    $params = @{ }
+                    $params = @{}
                     $params.Add("Uri", $Url)
                     $params.Add("Method", $Method)
                     $params.Add("Headers", $Headers)
@@ -259,7 +259,7 @@ function Invoke-GHRestMethod
 
                     try
                     {
-                        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+                        [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                         Invoke-WebRequest @params
                     }
                     catch [System.Net.WebException]
@@ -270,7 +270,7 @@ function Invoke-GHRestMethod
                         # information that we actually care about *now*, and then we'll throw our own exception
                         # that is just a JSON object with the data that we'll later extract for processing in
                         # the main catch.
-                        $ex = @{ }
+                        $ex = @{}
                         $ex.Message = $_.Exception.Message
                         $ex.StatusCode = $_.Exception.Response.StatusCode
                         $ex.StatusDescription = $_.Exception.Response.StatusDescription
@@ -381,18 +381,18 @@ function Invoke-GHRestMethod
         if ($ExtendedResult)
         {
             $finalResultEx = @{
-                'result'             = $finalResult
-                'statusCode'         = $result.StatusCode
-                'requestId'          = $result.Headers['X-GitHub-Request-Id']
-                'nextLink'           = $nextLink
-                'link'               = $result.Headers['Link']
-                'lastModified'       = $result.Headers['Last-Modified']
-                'ifNoneMatch'        = $result.Headers['If-None-Match']
-                'ifModifiedSince'    = $result.Headers['If-Modified-Since']
-                'eTag'               = $result.Headers['ETag']
-                'rateLimit'          = $result.Headers['X-RateLimit-Limit']
+                'result' = $finalResult
+                'statusCode' = $result.StatusCode
+                'requestId' = $result.Headers['X-GitHub-Request-Id']
+                'nextLink' = $nextLink
+                'link' = $result.Headers['Link']
+                'lastModified' = $result.Headers['Last-Modified']
+                'ifNoneMatch' = $result.Headers['If-None-Match']
+                'ifModifiedSince' = $result.Headers['If-Modified-Since']
+                'eTag' = $result.Headers['ETag']
+                'rateLimit' = $result.Headers['X-RateLimit-Limit']
                 'rateLimitRemaining' = $result.Headers['X-RateLimit-Remaining']
-                'rateLimitReset'     = $result.Headers['X-RateLimit-Reset']
+                'rateLimitReset' = $result.Headers['X-RateLimit-Reset']
             }
 
             return ([PSCustomObject] $finalResultEx)
@@ -530,7 +530,7 @@ function Invoke-GHRestMethod
 
 function Invoke-GHRestMethodMultipleResult
 {
-    <#
+<#
     .SYNOPSIS
         A special-case wrapper around Invoke-GHRestMethod that understands GET URI's
         which support the 'top' and 'max' parameters.
@@ -605,7 +605,7 @@ function Invoke-GHRestMethodMultipleResult
         shown to the user until a response is returned from the REST request.
 #>
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
     [OutputType([Object[]])]
     param(
         [Parameter(Mandatory)]
@@ -620,7 +620,7 @@ function Invoke-GHRestMethodMultipleResult
 
         [string] $TelemetryEventName = $null,
 
-        [hashtable] $TelemetryProperties = @{ },
+        [hashtable] $TelemetryProperties = @{},
 
         [string] $TelemetryExceptionBucket = $null,
 
@@ -645,18 +645,17 @@ function Invoke-GHRestMethodMultipleResult
 
     try
     {
-        do
-        {
+        do {
             $params = @{
-                'UriFragment'              = $nextLink
-                'Method'                   = 'Get'
-                'Description'              = $currentDescription
-                'AcceptHeader'             = $AcceptHeader
-                'ExtendedResult'           = $true
-                'AccessToken'              = $AccessToken
-                'TelemetryProperties'      = $telemetryProperties
+                'UriFragment' = $nextLink
+                'Method' = 'Get'
+                'Description' = $currentDescription
+                'AcceptHeader' = $AcceptHeader
+                'ExtendedResult' = $true
+                'AccessToken' = $AccessToken
+                'TelemetryProperties' = $telemetryProperties
                 'TelemetryExceptionBucket' = $errorBucket
-                'NoStatus'                 = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
+                'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
             }
 
             $result = Invoke-GHRestMethod @params
@@ -685,7 +684,7 @@ function Invoke-GHRestMethodMultipleResult
 
 function Split-GitHubUri
 {
-    <#
+<#
     .SYNOPSIS
         Extracts the relevant elements of a GitHub repository Uri and returns the requested element.
 
@@ -723,22 +722,22 @@ function Split-GitHubUri
 
         PowerShell
 #>
-    [CmdletBinding(DefaultParametersetName = 'RepositoryName')]
+    [CmdletBinding(DefaultParametersetName='RepositoryName')]
     param
     (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string] $Uri,
 
-        [Parameter(ParameterSetName = 'OwnerName')]
+        [Parameter(ParameterSetName='OwnerName')]
         [switch] $OwnerName,
 
-        [Parameter(ParameterSetName = 'RepositoryName')]
+        [Parameter(ParameterSetName='RepositoryName')]
         [switch] $RepositoryName
     )
 
     $components = @{
-        ownerName      = [String]::Empty
+        ownerName = [String]::Empty
         repositoryName = [String]::Empty
     }
 
@@ -766,7 +765,7 @@ function Split-GitHubUri
 
 function Resolve-RepositoryElements
 {
-    <#
+<#
     .SYNOPSIS
         Determines the OwnerName and RepositoryName from the possible parameter values.
 
@@ -791,8 +790,8 @@ function Resolve-RepositoryElements
         [PSCutomObject] - The OwnerName and RepositoryName elements to be used
 #>
     [CmdletBinding(SupportsShouldProcess)]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification = "This was the most accurate name that I could come up with.  Internal only anyway.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseSingularNouns", "", Justification="This was the most accurate name that I could come up with.  Internal only anyway.")]
     param
     (
         $BoundParameters = (Get-Variable -Name PSBoundParameters -Scope 1 -ValueOnly),
@@ -801,10 +800,10 @@ function Resolve-RepositoryElements
     )
 
     $validate = -not $DisableValidation
-    $elements = @{ }
+    $elements = @{}
 
     if ($BoundParameters.ContainsKey('Uri') -and
-        ($BoundParameters.ContainsKey('OwnerName') -or $BoundParameters.ContainsKey('RepositoryName')))
+       ($BoundParameters.ContainsKey('OwnerName') -or $BoundParameters.ContainsKey('RepositoryName')))
     {
         $message = "Cannot specify a Uri AND individual OwnerName/RepositoryName.  Please choose one or the other."
         Write-Log -Message $message -Level Error
@@ -860,7 +859,7 @@ $script:datePropertyNames = @(
 
 filter ConvertTo-SmarterObject
 {
-    <#
+<#
     .SYNOPSIS
         Updates the properties of the input object to be object themselves when the conversion
         is possible.
@@ -893,8 +892,8 @@ filter ConvertTo-SmarterObject
     if ($InputObject -is [System.Collections.IList])
     {
         $InputObject |
-        ConvertTo-SmarterObject |
-        Write-Output
+            ConvertTo-SmarterObject |
+            Write-Output
     }
     elseif ($InputObject -is [PSCustomObject])
     {
@@ -937,7 +936,7 @@ filter ConvertTo-SmarterObject
 
 function Get-MediaAcceptHeader
 {
-    <#
+<#
     .DESCRIPTION
         Returns a formatted AcceptHeader based on the requested MediaType
 


### PR DESCRIPTION
Per the [documentation](https://developer.github.com/enterprise/2.16/v3/#current-version), enterprise installations support a base URL of  `http(s)://[hostname]/api/v3` in addition to the existing support of `http(s)://api.[hostname]/`.  This PR updates the module to _always_ use the `http(s)://[hostname]/api/v3` syntax when `[hostname]` is _not_ `github.com`.

Fixes #117