### PR TITLE
Minor test cleanup

### DIFF
--- a/Tests/GitHubAnalytics.tests.ps1
+++ b/Tests/GitHubAnalytics.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try
@@ -245,14 +245,14 @@ try
         $original = Get-GitHubRepository -OrganizationName $script:organizationName
 
         $repositoryName = [guid]::NewGuid().Guid
-        $null = New-GitHubRepository -RepositoryName $repositoryName -OrganizationName $script:organizationName
+        $repo = New-GitHubRepository -RepositoryName ([guid]::NewGuid().Guid) -OrganizationName $script:organizationName
         $current = Get-GitHubRepository -OrganizationName $script:organizationName
 
         It 'Should return expected number of organization repositories' {
             (@($current).Count - @($original).Count) | Should be 1
         }
 
-        $null = Remove-GitHubRepository -OwnerName $script:organizationName -RepositoryName $repositoryName
+        $null = Remove-GitHubRepository -Uri $repo.svn_url
     }
 
     Describe 'Getting unique contributors from contributors array' {

--- a/Tests/GitHubAssignees.tests.ps1
+++ b/Tests/GitHubAssignees.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubComments.tests.ps1
+++ b/Tests/GitHubComments.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubCore.Tests.ps1
+++ b/Tests/GitHubCore.Tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubEvents.tests.ps1
+++ b/Tests/GitHubEvents.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubLabels.tests.ps1
+++ b/Tests/GitHubLabels.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubMilestones.tests.ps1
+++ b/Tests/GitHubMilestones.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubRepositoryForks.tests.ps1
+++ b/Tests/GitHubRepositoryForks.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try

--- a/Tests/GitHubRepositoryTraffic.tests.ps1
+++ b/Tests/GitHubRepositoryTraffic.tests.ps1
@@ -7,7 +7,7 @@
 #>
 
 # This is common test code setup logic for all Pester test files
-$moduleRootPath = Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 . (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
 
 try


### PR DESCRIPTION
Adopting `$PSScriptRoot` to simplify path access,
and making a minor code simplification in a test.