### PR TITLE
Ensure Milestone due_on always gets set to desired date

### DIFF
--- a/Tests/GitHubMilestones.tests.ps1
+++ b/Tests/GitHubMilestones.tests.ps1
@@ -17,6 +17,8 @@ try
         defaultIssueTitle = "This is a test issue."
         defaultMilestoneTitle1 = "This is a test milestone title #1."
         defaultMilestoneTitle2 = "This is a test milestone title #2."
+        defaultMilestoneTitle3 = "This is a test milestone title #3."
+        defaultMilestoneTitle4 = "This is a test milestone title #4."
         defaultEditedMilestoneTitle = "This is an edited milestone title."
         defaultMilestoneDescription = "This is a test milestone description."
         defaultEditedMilestoneDescription = "This is an edited milestone description."
@@ -33,6 +35,10 @@ try
             $newMilestone = New-GitHubMilestone -Uri $repo.svn_url -Title $defaultMilestoneTitle1 -State "Closed" -DueOn $defaultMilestoneDueOn
             $existingMilestone = Get-GitHubMilestone -Uri $repo.svn_url -Milestone $newMilestone.number
 
+            # We'll be testing to make sure that regardless of the time in the timestamp, we'll get the desired date.
+            $newMilestoneDueOnEarlyMorning = New-GitHubMilestone -Uri $repo.svn_url -Title $defaultMilestoneTitle2 -State "Closed" -DueOn $defaultMilestoneDueOn.date.AddHours(1)
+            $newMilestoneDueOnLateEvening = New-GitHubMilestone -Uri $repo.svn_url -Title $defaultMilestoneTitle3 -State "Closed" -DueOn $defaultMilestoneDueOn.date.AddHours(23)
+
             It "Should have the expected title text" {
                 $existingMilestone.title | Should be $defaultMilestoneTitle1
             }
@@ -42,7 +48,21 @@ try
             }
 
             It "Should have the expected due_on date" {
+                # GitHub drops the time that is attached to 'due_on', so it's only relevant
+                # to compare the dates against each other.
                 (Get-Date -Date $existingMilestone.due_on).Date | Should be $defaultMilestoneDueOn.Date
+            }
+
+            It "Should have the expected due_on date even if early morning" {
+                # GitHub drops the time that is attached to 'due_on', so it's only relevant
+                # to compare the dates against each other.
+                (Get-Date -Date $newMilestoneDueOnEarlyMorning.due_on).Date | Should be $defaultMilestoneDueOn.Date
+            }
+
+            It "Should have the expected due_on date even if late evening" {
+                # GitHub drops the time that is attached to 'due_on', so it's only relevant
+                # to compare the dates against each other.
+                (Get-Date -Date $newMilestoneDueOnLateEvening.due_on).Date | Should be $defaultMilestoneDueOn.Date
             }
 
             It "Should allow the addition of an existing issue" {
@@ -55,7 +75,7 @@ try
             $issue = Get-GitHubIssue -Uri $repo.svn_url -Issue $issue.number
 
             It 'Should have the expected number of milestones' {
-                $existingMilestones.Count | Should be 1
+                $existingMilestones.Count | Should be 3
             }
 
             It 'Should have the expected title text on the first milestone' {
@@ -69,7 +89,7 @@ try
         }
 
         Context 'For editing a milestone' {
-            $newMilestone = New-GitHubMilestone -Uri $repo.svn_url -Title $defaultMilestoneTitle2 -Description $defaultMilestoneDescription
+            $newMilestone = New-GitHubMilestone -Uri $repo.svn_url -Title $defaultMilestoneTitle4 -Description $defaultMilestoneDescription
             $editedMilestone = Set-GitHubMilestone -Uri $repo.svn_url -Milestone $newMilestone.number -Title $defaultEditedMilestoneTitle -Description $defaultEditedMilestoneDescription
 
             It 'Should have a title/description that is not equal to the original title/description' {
@@ -87,7 +107,7 @@ try
             $existingMilestones = @(Get-GitHubMilestone -Uri $repo.svn_url -State All -Sort Completeness -Direction Descending)
 
             It 'Should have the expected number of milestones' {
-                $existingMilestones.Count | Should be 2
+                $existingMilestones.Count | Should be 4
             }
 
             foreach($milestone in $existingMilestones) {


### PR DESCRIPTION
The "Should have the expected due_on date" UT was failing, but
only at certain times of the day.  Further investigation uncovered
this support forum post:

  https://github.community/t5/How-to-use-Git-and-GitHub/Milestone-quot-Due-On-quot-field-defaults-to-7-00-when-set-by-v3/m-p/6901

In the event that the post goes away at some point, I will archive
what it says here:

> This is an artifact of how GitHub was originally designed.
> To my recollection, all timestamps in the database are
> normalized to Pacific time. So yes, this is the expected behavior.
> [The time used will vary] because midnight Pacific time is
> 7AM or 8AM UTC time depending on whether Pacific time is in
> daylight savings or not on that date.

Given this information, the problem was then quite clear.

Examples:

 * If you set 'due_on' to be '2020-09-24T06:59:00Z',
   GitHub considers that to be '2020-09-23T07:00:00Z'
   (the previous day!!)
 * And if you set 'due_on' to be '2020-09-24T07:01:00Z',
   GitHub considers that to be '2020-09-24T07:00:00Z'
   (the correct day)

Given this, I've modified `New-GitHubMilestone` and `Set-GitHubMilestone`
to drop the user's provided time (since GitHub does that anyway), and
instead always add 9 hours from midnight (UTC) to the provided
date, which bypasses having to check if we're in daylight savings time
or not.

I then added two additional UT's to ensure we don't lose that functionality.

Finally, I updated the documentation in those methods to try to make it more
clear to users what is going to happen with the date/time that they provide.

Fixes #92