### PR TITLE
Fix Update-GitHubRepository to properly handle the -Archived switch

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -522,7 +522,7 @@ function Update-GitHubRepository
         By default, rebase-merge pull requests will be allowed.
         Specify this to disallow.
 
-    .PARAMETER DisallowRebaseMerge
+    .PARAMETER Archived
         Specify this to archive this repository.
         NOTE: You cannot unarchive repositories through the API / this module.
 
@@ -610,7 +610,7 @@ function Update-GitHubRepository
     if ($PSBoundParameters.ContainsKey('DisallowSquashMerge')) { $hashBody['allow_squash_merge'] = (-not $DisallowSquashMerge.ToBool()) }
     if ($PSBoundParameters.ContainsKey('DisallowMergeCommit')) { $hashBody['allow_merge_commit'] = (-not $DisallowMergeCommit.ToBool()) }
     if ($PSBoundParameters.ContainsKey('DisallowRebaseMerge')) { $hashBody['allow_rebase_merge'] = (-not $DisallowRebaseMerge.ToBool()) }
-    if ($PSBoundParameters.ContainsKey('Archived')) { $hashBody['archived'] = (-not $Archived.ToBool()) }
+    if ($PSBoundParameters.ContainsKey('Archived')) { $hashBody['archived'] = $Archived.ToBool() }
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$ReposistoryName"


### PR DESCRIPTION
Due to a copy-paste error, the function was incorrectly inverting the
user's choice.

A separate work item will be created to track adding some additional
tests to this part of the code.

Fixes #134