### PR TITLE
Fix Update-GitHubRepository typo resulting in incorrect REST endpoint

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -613,7 +613,7 @@ function Update-GitHubRepository
     if ($PSBoundParameters.ContainsKey('Archived')) { $hashBody['archived'] = $Archived.ToBool() }
 
     $params = @{
-        'UriFragment' = "repos/$OwnerName/$ReposistoryName"
+        'UriFragment' = "repos/$OwnerName/$RepositoryName"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Patch'
         'Description' =  "Updating $RepositoryName"


### PR DESCRIPTION
There was a typo in `$RepositoryName` which was being referenced to
generate the REST endpoint used for `Update-GitHubRepository`.