### PR TITLE
Fixing version badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PowerShellForGitHub PowerShell Module
 
-[![[GitHub version]](https://badge.fury.io/gh/PowerShell%2FPowerShellForGitHub.svg)](https://badge.fury.io/gh/PowerShell%2FPowerShellForGitHub)
+[![[GitHub version]](https://badge.fury.io/gh/microsoft%2FPowerShellForGitHub.svg)](https://badge.fury.io/gh/microsoft%2FPowerShellForGitHub)
 [![Build status](https://dev.azure.com/ms/PowerShellForGitHub/_apis/build/status/PowerShellForGitHub-CI?branchName=master)](https://dev.azure.com/ms/PowerShellForGitHub/_build/latest?definitionId=109&branchName=master)
 
 #### Table of Contents


### PR DESCRIPTION
The version badge was still referencing the old GitHub repo
(`PowerShell/PowerShellForGitHub) and was causing some issues.
Migrating it to point to the new `microsoft/PowerShellForGitHub` repo.