### PR TITLE
Add ability to rename a repository: Rename-GitHubRepository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,6 +481,7 @@ Thank you to all of our contributors, no matter how big or small the contributio
 - **[Darío Hereñú (@kant)](https://github.com/kant)**
 - **[@wikijm](https://github.com/wikijm)**
 - **[Przemysław Kłys (@PrzemyslawKlys)](https://github.com/PrzemyslawKlys)**
+- **[Matt Boren (@mtboren)](http://github.com/mtboren)**
 
 
 

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -512,6 +512,12 @@ function Rename-GitHubRepository
         ConfirmImpact="High")]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
     param(
+        [Parameter(Mandatory=$true, ParameterSetName='Elements')]
+        [string] $OwnerName,
+
+        [Parameter(Mandatory=$true, ParameterSetName='Elements')]
+        [string] $RepositoryName,
+
         [Parameter(
             Mandatory,
             ValueFromPipelineByPropertyName,
@@ -527,7 +533,8 @@ function Rename-GitHubRepository
     )
 
     process {
-        if ($PSCmdlet.ShouldProcess("$Uri", "Rename repository to '$NewName'")) {
+        if ($PSCmdlet.ShouldProcess($(if ($PSCmdlet.ParameterSetName -eq "Uri") {$Uri} else {$OwnerName, $RepositoryName -join "/"}), "Rename repository to '$NewName'"))
+        {
             Write-InvocationLog -Invocation $MyInvocation
             $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
             $OwnerName = $elements.ownerName
@@ -541,7 +548,7 @@ function Rename-GitHubRepository
             $params = @{
                 'UriFragment' = "repos/$OwnerName/$RepositoryName"
                 'Method' = 'Patch'
-                Body = @{name = $NewName} | ConvertTo-Json
+                Body = ConvertTo-Json -InputObject @{name = $NewName}
                 'Description' =  "Renaming repository at '$Uri' to '$NewName'"
                 'AccessToken' = $AccessToken
                 'TelemetryEventName' = $MyInvocation.MyCommand.Name

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -490,20 +490,21 @@ function Rename-GitHubRepository
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
     .EXAMPLE
-        Get-GitHubRepository -Owner myGithubUsername -RepositoryName myRepoToReanme | Rename-GitHubRepository -NewName myNewRepoNameIsSoSweet
-        Get the given repository and rename it with the new name
+        Get-GitHubRepository -Owner octocat -RepositoryName hello-world | Rename-GitHubRepository -NewName hello-again-world
+        Get the given 'hello-world' repo from the user 'octocat' and rename it to be https://github.com/octocat/hello-again-world.
+
 
     .EXAMPLE
-        Get-GitHubRepository -Uri https://github.com/mystuff/myRepoToReanme | Rename-GitHubRepository -NewName myNewRepoNameIsSoSweet
-        Get the repository at the given URI and rename it with the new name
+        Get-GitHubRepository -Uri https://github.com/octocat/hello-world | Rename-GitHubRepository -NewName hello-again-world
+        Get the repository at https://github.com/octocat/hello-world and then rename it https://github.com/octocat/hello-again-world.
 
     .EXAMPLE
-        Rename-GitHubRepository -Uri https://github.com/mystuff/myRepoToReanme -NewName myNewRepoNameIsSoSweet
-        Rename the repository that is at the given URI with the new name
+        Rename-GitHubRepository -Uri https://github.com/octocat/hello-world -NewName hello-again-world
+        Rename the repository at https://github.com/octocat/hello-world to https://github.com/octocat/hello-again-world.
 
     .EXAMPLE
-        New-GitHubRepositoryFork -Uri https://github.com/someoneElse/coolRepoForStuff | Foreach-Object {$_ | Rename-GitHubRepository -NewName "$($_.name)_fork"}
-        Fork the repository from the given URI, and then rename the newly forked repository with the new name (appending '_fork' to the name of new repo)
+        New-GitHubRepositoryFork -Uri https://github.com/octocat/hello-world | Foreach-Object {$_ | Rename-GitHubRepository -NewName "$($_.name)_fork"}
+        Fork the `hello-world` repository from the user 'octocat', and then rename the newly forked repository by appending '_fork'.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -535,7 +536,7 @@ function Rename-GitHubRepository
             $telemetryProperties = @{
                 'OwnerName' = (Get-PiiSafeString -PlainText $OwnerName)
                 'RepositoryName' = (Get-PiiSafeString -PlainText $RepositoryName)
-            } ## end hsh
+            }
 
             $params = @{
                 'UriFragment' = "repos/$OwnerName/$RepositoryName"
@@ -546,11 +547,11 @@ function Rename-GitHubRepository
                 'TelemetryEventName' = $MyInvocation.MyCommand.Name
                 'TelemetryProperties' = $telemetryProperties
                 'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -BoundParameters $PSBoundParameters -Name NoStatus -ConfigValueName DefaultNoStatus)
-            } ## end hsh
+            }
 
             return Invoke-GHRestMethod @params
-        } ## end if
-    } ## end process
+        }
+    }
 }
 
 function Update-GitHubRepository

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -500,11 +500,9 @@ function Rename-GitHubRepository
     .EXAMPLE
         Get-GitHubRepository -Owner octocat -RepositoryName hello-world | Rename-GitHubRepository -NewName hello-again-world
         Get the given 'hello-world' repo from the user 'octocat' and rename it to be https://github.com/octocat/hello-again-world.
-
-
     .EXAMPLE
         Get-GitHubRepository -Uri https://github.com/octocat/hello-world | Rename-GitHubRepository -NewName hello-again-world -Confirm:$false
-        Get the repository at https://github.com/octocat/hello-world and then rename it https://github.com/octocat/hello-again-world. Will not prompt for confirmation, as the -Confirm:$false parameter/value were passed.
+        Get the repository at https://github.com/octocat/hello-world and then rename it https://github.com/octocat/hello-again-world. Will not prompt for confirmation, as -Confirm:$false was specified.
 
     .EXAMPLE
         Rename-GitHubRepository -Uri https://github.com/octocat/hello-world -NewName hello-again-world
@@ -542,7 +540,7 @@ function Rename-GitHubRepository
 
     process
     {
-        $strRepositoryInfoForDisplayMessage = if ($PSCmdlet.ParameterSetName -eq "Uri") {$Uri} else {$OwnerName, $RepositoryName -join "/"}
+        $repositoryInfoForDisplayMessage = if ($PSCmdlet.ParameterSetName -eq "Uri") { $Uri } else { $OwnerName, $RepositoryName -join "/" }
         if ($PSCmdlet.ShouldProcess($strRepositoryInfoForDisplayMessage, "Rename repository to '$NewName'"))
         {
             Write-InvocationLog -Invocation $MyInvocation
@@ -559,7 +557,7 @@ function Rename-GitHubRepository
                 'UriFragment' = "repos/$OwnerName/$RepositoryName"
                 'Method' = 'Patch'
                 Body = ConvertTo-Json -InputObject @{name = $NewName}
-                'Description' =  "Renaming repository at '$strRepositoryInfoForDisplayMessage' to '$NewName'"
+                'Description' =  "Renaming repository at '$repositoryInfoForDisplayMessage' to '$NewName'"
                 'AccessToken' = $AccessToken
                 'TelemetryEventName' = $MyInvocation.MyCommand.Name
                 'TelemetryProperties' = $telemetryProperties

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -472,6 +472,14 @@ function Rename-GitHubRepository
 
         The Git repo for this module can be found here: http://aka.ms/PowerShellForGitHub
 
+    .PARAMETER OwnerName
+        Owner of the repository.
+        If not supplied here, the DefaultOwnerName configuration property value will be used.
+
+    .PARAMETER RepositoryName
+        Name of the repository.
+        If not supplied here, the DefaultRepositoryName configuration property value will be used.
+
     .PARAMETER Uri
         Uri for the repository to rename. You can supply this directly, or more easily by
         using Get-GitHubRepository to get the repository as you please, and then piping the result to this cmdlet
@@ -495,8 +503,8 @@ function Rename-GitHubRepository
 
 
     .EXAMPLE
-        Get-GitHubRepository -Uri https://github.com/octocat/hello-world | Rename-GitHubRepository -NewName hello-again-world
-        Get the repository at https://github.com/octocat/hello-world and then rename it https://github.com/octocat/hello-again-world.
+        Get-GitHubRepository -Uri https://github.com/octocat/hello-world | Rename-GitHubRepository -NewName hello-again-world -Confirm:$false
+        Get the repository at https://github.com/octocat/hello-world and then rename it https://github.com/octocat/hello-again-world. Will not prompt for confirmation, as the -Confirm:$false parameter/value were passed.
 
     .EXAMPLE
         Rename-GitHubRepository -Uri https://github.com/octocat/hello-world -NewName hello-again-world
@@ -532,8 +540,10 @@ function Rename-GitHubRepository
         [switch] $NoStatus
     )
 
-    process {
-        if ($PSCmdlet.ShouldProcess($(if ($PSCmdlet.ParameterSetName -eq "Uri") {$Uri} else {$OwnerName, $RepositoryName -join "/"}), "Rename repository to '$NewName'"))
+    process
+    {
+        $strRepositoryInfoForDisplayMessage = if ($PSCmdlet.ParameterSetName -eq "Uri") {$Uri} else {$OwnerName, $RepositoryName -join "/"}
+        if ($PSCmdlet.ShouldProcess($strRepositoryInfoForDisplayMessage, "Rename repository to '$NewName'"))
         {
             Write-InvocationLog -Invocation $MyInvocation
             $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
@@ -549,7 +559,7 @@ function Rename-GitHubRepository
                 'UriFragment' = "repos/$OwnerName/$RepositoryName"
                 'Method' = 'Patch'
                 Body = ConvertTo-Json -InputObject @{name = $NewName}
-                'Description' =  "Renaming repository at '$Uri' to '$NewName'"
+                'Description' =  "Renaming repository at '$strRepositoryInfoForDisplayMessage' to '$NewName'"
                 'AccessToken' = $AccessToken
                 'TelemetryEventName' = $MyInvocation.MyCommand.Name
                 'TelemetryProperties' = $telemetryProperties

--- a/PowerShellForGitHub.psd1
+++ b/PowerShellForGitHub.psd1
@@ -102,6 +102,7 @@
         'Remove-GitHubLabel',
         'Remove-GitHubMilestone',
         'Remove-GitHubRepository',
+        'Rename-GitHubRepository',
         'Reset-GitHubConfiguration',
         'Restore-GitHubConfiguration',
         'Set-GitHubAuthentication',

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -19,23 +19,23 @@ try
         Context -Name 'For renaming a repository' -Fixture {
             BeforeEach -Scriptblock {
                 $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
-                $strSuffixToAddToRepo = "_renamed"
-                $strNewRepoName = "$($repo.Name)$strSuffixToAddToRepo"
-                Write-Verbose "New repo name shall be: '$strNewRepoName'"
+                $suffixToAddToRepo = "_renamed"
+                $newRepoName = "$($repo.Name)$suffixToAddToRepo"
+                Write-Verbose "New repo name shall be: '$newRepoName'"
             }
             It "Should have the expected new repository name - by URI" {
-                $renamedRepo = $repo | Rename-GitHubRepository -NewName $strNewRepoName -Confirm:$false
-                $renamedRepo.Name | Should be $strNewRepoName
+                $renamedRepo = $repo | Rename-GitHubRepository -NewName $newRepoName -Confirm:$false
+                $renamedRepo.Name | Should be $newRepoName
             }
 
             It "Should have the expected new repository name - by Elements" {
-                $renamedRepo = Rename-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -NewName $strNewRepoName -Confirm:$false
-                $renamedRepo.Name | Should be $strNewRepoName
+                $renamedRepo = Rename-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -NewName $newRepoName -Confirm:$false
+                $renamedRepo.Name | Should be $newRepoName
             }
             ## cleanup temp testing repository
             AfterEach -Scriptblock {
                 ## variables from BeforeEach scriptblock are accessible here, but not variables from It scriptblocks, so need to make URI (instead of being able to use $renamedRepo variable from It scriptblock)
-                Remove-GitHubRepository -Uri "$($repo.svn_url)$strSuffixToAddToRepo" -Verbose
+                Remove-GitHubRepository -Uri "$($repo.svn_url)$suffixToAddToRepo" -Verbose
             }
         }
     }

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+   Tests for GitHubRepositories.ps1 module
+.Description
+    Many cmdlets are indirectly tested in the course of other tests (New-GitHubRepository, Remove-GitHubRepository), and may not have explicit tests here
+#>
+
+# This is common test code setup logic for all Pester test files
+$moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
+. (Join-Path -Path $moduleRootPath -ChildPath 'Tests\Common.ps1')
+
+try
+{
+    Describe 'Modifying repositories' {
+        $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
+        $strNewRepoName = "$($repo.Name)_renamed"
+        $renamedRepo = $repo | Rename-GitHubRepository -NewName $strNewRepoName -Confirm:$false
+
+        Context 'For renaming a repository' {
+            It "Should have the expected new repository name" {
+                $renamedRepo.Name | Should be $strNewRepoName
+            }
+        }
+
+        Remove-GitHubRepository -Uri $renamedRepo.svn_url
+    }
+}
+finally
+{
+    if (Test-Path -Path $script:originalConfigFile -PathType Leaf)
+    {
+        # Restore the user's configuration to its pre-test state
+        Restore-GitHubConfiguration -Path $script:originalConfigFile
+        $script:originalConfigFile = $null
+    }
+}


### PR DESCRIPTION
This adds the ability to easily rename a repository via the new cmdlet `Rename-GitHubRepository`, as suggested in #144 .  As we see in the diff, this PR:

- adds the new cmdlet
- adds a test for the new cmdlet
- adds a new contributor

Running `PSScriptAnalyzer` returns no issue (returned `$null`), and `Pester` test results were unchanged except that there is now one new, successful test.

How does this look as an add to this great module?
