### PR TITLE
Updating macOS image used in CI pipeline

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -37,7 +37,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   steps:
   - template: ./templates/verify-testConfigSettingsHash.yaml
   - template: ./templates/run-staticAnalysis.yaml


### PR DESCRIPTION
Per this blog post https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/