### PR TITLE
Remove AppVeyor references from docs and code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -352,18 +352,19 @@ There are many more nuances to code-coverage, see
 [![Build status](https://dev.azure.com/ms/PowerShellForGitHub/_apis/build/status/PowerShellForGitHub-CI?branchName=master)](https://dev.azure.com/ms/PowerShellForGitHub/_build/latest?definitionId=109&branchName=master)
 
 These test are configured to automatically execute upon any update to the `master` branch
-on the `HowardWolosky` fork of `PowerShellForGitHub`.  (At this time, we don't have the proper
-permissions to have AppVeyor execute the tests on the main instance.)  This setup thus depends
-on the `HowardWolosky` fork always being kept up-to-date with the `PowerShell` master.
+of `microsoft/PowerShellForGitHub`.
 
-The [AppVeyor project](https://ci.appveyor.com/project/HowardWolosky/powershellforgithub) has
-been [configured](./appveyor.yml) to execute the tests against a test GitHub account (for the user
-`PowerShellForGitHubTeam`, and the org `PowerShellForGitHubTeamTestOrg`).
-
-Additionally, the Access Token with administrator access for that account has been encrypted on
-AppVeyor and mentioned in the [config file](./appveyor.yml).  That Access Token is not accessible
-by anyone else.  To run the tests locally with your own account, see
+The [Azure DevOps pipeline](https://dev.azure.com/ms/PowerShellForGitHub/_build?definitionId=109&_a=summary)
+has been [configured](https://github.com/microsoft/PowerShellForGitHub/blob/master/build/pipelines/templates/run-unitTests.yaml#L25-L28)
+to execute the tests against a test GitHub account (for the user `PowerShellForGitHubTeam`,
+and the org `PowerShellForGitHubTeamTestOrg`).  You will see the AccessToken being referenced there
+as well...it is stored, encryted, within Azure DevOps.  It is not accessible for use outside of
+the CI pipeline.  To run the tests locally with your own account, see
 [configuring-your-environment](#configuring-your-environment).
+
+> NOTE: We're currently encountering issues with the tests successfully running within the pipeline.
+> They do complete successfully locally, so please test your changes locally before submitting a
+> pull request.
 
 #### New Test Guidelines
 Your tests should have NO dependencies on an account being set up in a specific way.  They should

--- a/Tests/Common.ps1
+++ b/Tests/Common.ps1
@@ -29,7 +29,7 @@ function Initialize-CommonTestSetup
         This method is invoked immediately after the declaration.
 #>
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in AppVeyor.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "", Justification="Needed to configure with the stored, encrypted string value in Azure DevOps.")]
     param()
 
     $moduleRootPath = Split-Path -Path $PSScriptRoot -Parent


### PR DESCRIPTION
AppVeyor hasn't been in use since d6c3b5354bfaa6538123798cc97f684f273140de