### PR TITLE
Make Get-SHA512Hash available for use during Pester execution

### DIFF
--- a/Tests/Common.ps1
+++ b/Tests/Common.ps1
@@ -37,6 +37,11 @@ function Initialize-CommonTestSetup
     . $settingsPath
     Import-Module -Name (Join-Path -Path $moduleRootPath -ChildPath 'PowerShellForGitHub.psd1') -Force
 
+    # Get-SHA512 is an internal helper function that is not normally exposed.
+    # We need to explicitly load it into our execution context in order to use it below.
+    $moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
+    . (Join-Path -Path $moduleRootPath -ChildPath 'Helpers.ps1')
+
     $originalSettingsHash = (Get-GitHubConfiguration -Name TestConfigSettingsHash)
     $currentSettingsHash = Get-SHA512Hash -PlainText (Get-Content -Path $settingsPath -Raw -Encoding Utf8)
     $settingsAreUnaltered = $originalSettingsHash -eq $currentSettingsHash


### PR DESCRIPTION
89f69f1132505f04e6b2ac38b6f5a93aef6ac947 introduced the usage of
`Get-SHA512Hash` to determine if the Settings.ps1 file had been
altered, however that's a non-exported function.

This now loads `Helpers.ps1` into the context of the Pester test
execution so that the function can be found.