### PR TITLE
Ensure progress bar for Wait-JobWithAnimation gets marked as Completed

### DIFF
--- a/Helpers.ps1
+++ b/Helpers.ps1
@@ -110,6 +110,9 @@ function Wait-JobWithAnimation
         $iteration++
     }
 
+    # Ensure that we complete the progress bar once the command is done, regardless of outcome.
+    Write-Progress -Activity $Description -Id $progressId -Completed
+
     # We'll wrap the description (if provided) in brackets for display purposes.
     if (-not [string]::IsNullOrWhiteSpace($Description))
     {


### PR DESCRIPTION
Per helpful feedback from @StartAutomating:

>Taking a brief look at implementation, I don't see where you send -Completed message to Write-Progress.
>
>This will cause progress bars to stay visible while any other commands in the script execute.  E.g. if you ran a Get- that returned many results, and piped to an expensive Foreach-Object, your progress bar wouldn't go away until the Foreach-Object ended."