### PR TITLE
Fix the behavior of Get-GitHubRepository

### DIFF
--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -6,6 +6,12 @@
     mediaTypeVersion = 'v3'
     squirrelAcceptHeader = 'application/vnd.github.squirrel-girl-preview'
     symmetraAcceptHeader = 'application/vnd.github.symmetra-preview+json'
+    mercyAcceptHeader = 'application/vnd.github.mercy-preview+json'
+    nebulaAcceptHeader = 'application/vnd.github.nebula-preview+json'
+    baptisteAcceptHeader = 'application/vnd.github.baptiste-preview+json'
+    scarletWitchAcceptHeader = 'application/vnd.github.scarlet-witch-preview+json'
+    dorianAcceptHeader = 'application/vnd.github.dorian-preview+json'
+    londonAcceptHeader = 'application/vnd.github.london-preview+json'
 
  }.GetEnumerator() | ForEach-Object {
      Set-Variable -Scope Script -Option ReadOnly -Name $_.Key -Value $_.Value

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -14,8 +14,107 @@ $moduleRootPath = Split-Path -Path $PSScriptRoot -Parent
 
 try
 {
-    Describe 'Modifying repositories' {
+    Describe 'Getting repositories' {
+        Context 'For authenticated user' {
+            BeforeAll -Scriptblock {
+                $publicRepo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
+                $privateRepo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit -Private
 
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $publicRepo = $publicRepo
+                $privateRepo = $privateRepo
+            }
+
+            $publicRepos = Get-GitHubRepository -Visibility Public
+            $privateRepos = Get-GitHubRepository -Visibility Private
+
+            It "Should have the public repo" {
+                $publicRepo.Name | Should BeIn $publicRepos.Name
+                $publicRepo.Name | Should Not BeIn $privateRepos.Name
+            }
+
+            It "Should have the private repo" {
+                $privateRepo.Name | Should BeIn $privateRepos.Name
+                $privateRepo.Name | Should Not BeIn $publicRepos.Name
+            }
+
+            It 'Should not permit bad combination of parameters' {
+                { Get-GitHubRepository -Type All -Visibility All } | Should Throw
+                { Get-GitHubRepository -Type All -Affiliation Owner } | Should Throw
+            }
+
+            AfterAll -ScriptBlock {
+                Remove-GitHubRepository -Uri $publicRepo.svn_url
+                Remove-GitHubRepository -Uri $privateRepo.svn_url
+            }
+        }
+
+        Context 'For any user' {
+            $repos = Get-GitHubRepository -OwnerName 'octocat' -Type Public
+
+            It "Should have results for The Octocat" {
+                $repos.Count | Should -BeGreaterThan 0
+                $repos[0].owner.login | Should Be 'octocat'
+            }
+        }
+
+        Context 'For organizations' {
+            BeforeAll -Scriptblock {
+                $repo = New-GitHubRepository -OrganizationName $script:organizationName -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $repo = $repo
+            }
+
+            $repos = Get-GitHubRepository -OrganizationName $script:organizationName -Type All
+            It "Should have results for the organization" {
+                $repo.name | Should BeIn $repos.name
+            }
+
+            AfterAll -ScriptBlock {
+                Remove-GitHubRepository -Uri $repo.svn_url
+            }
+        }
+
+        Context 'For public repos' {
+            # Skipping these tests for now, as it would run for a _very_ long time.
+            # No obviously good way to verify this.
+        }
+
+        Context 'For a specific repo' {
+            BeforeAll -Scriptblock {
+                $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $repo = $repo
+            }
+
+            $returned = Get-GitHubRepository -Uri $repo.svn_url
+            It "Should be a single result using Uri ParameterSet" {
+                $returned | Should -BeOfType PSCustomObject
+            }
+
+            $returned = Get-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.Name
+            It "Should be a single result using Elements ParameterSet" {
+                $returned | Should -BeOfType PSCustomObject
+            }
+
+            It 'Should not permit additional parameters' {
+                { Get-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.Name -Type All } | Should Throw
+            }
+
+            It 'Should require both OwnerName and RepositoryName' {
+                { Get-GitHubRepository -RepositoryName $repo.Name } | Should Throw
+                { Get-GitHubRepository -Uri "https://github.com/$script:ownerName" } | Should Throw
+            }
+
+            AfterAll -ScriptBlock {
+                Remove-GitHubRepository -Uri $repo.svn_url
+            }
+        }
+    }
+
+    Describe 'Modifying repositories' {
         Context -Name 'For renaming a repository' -Fixture {
             BeforeEach -Scriptblock {
                 $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
@@ -35,7 +134,7 @@ try
             ## cleanup temp testing repository
             AfterEach -Scriptblock {
                 ## variables from BeforeEach scriptblock are accessible here, but not variables from It scriptblocks, so need to make URI (instead of being able to use $renamedRepo variable from It scriptblock)
-                Remove-GitHubRepository -Uri "$($repo.svn_url)$suffixToAddToRepo" -Verbose
+                Remove-GitHubRepository -Uri "$($repo.svn_url)$suffixToAddToRepo"
             }
         }
     }


### PR DESCRIPTION
There were a few problems with this function:
* -GetAllPublicRepositories didn't actually work.  That's now been fixed,
  and support for the optional Since paramater has been added as well.
* Fixed the ParameterSet handling for all of the parameters to make sure
  that users can only specify parameters relevant with the appropriate
  parameter set given that there are five different use cases for this
  method:
     * Getting repos for the current authenticated user
     * Getting repos for any GitHub user
     * Getting repos for an organization
     * Getting all public repos)
     * Getting a specific GitHub repo

Resolves #178
Helps with #139 