### PR TITLE
Get PSScriptAnalyzer clean again

### DIFF
--- a/GitHubAssignees.ps1
+++ b/GitHubAssignees.ps1
@@ -41,6 +41,7 @@ function Get-GitHubAssignee
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -128,6 +129,7 @@ function Test-GitHubAssignee
         DefaultParameterSetName='Elements')]
         [OutputType([bool])]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -228,6 +230,7 @@ function New-GithubAssignee
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -330,6 +333,7 @@ function Remove-GithubAssignee
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubBranches.ps1
+++ b/GitHubBranches.ps1
@@ -55,6 +55,7 @@ function Get-GitHubRepositoryBranch
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     [Alias('Get-GitHubBranch')]
     param(
         [Parameter(ParameterSetName='Elements')]

--- a/GitHubComments.ps1
+++ b/GitHubComments.ps1
@@ -244,6 +244,7 @@ function New-GitHubComment
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -355,6 +356,7 @@ function Set-GitHubComment
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -456,6 +458,7 @@ function Remove-GitHubComment
         DefaultParameterSetName='Elements')]
     [Alias('Delete-GitHubComment')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -612,6 +612,7 @@ function Invoke-GHRestMethodMultipleResult
 #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     [OutputType([Object[]])]
     param(
         [Parameter(Mandatory)]

--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -378,6 +378,7 @@ function Get-GitHubIssueTimeline
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -861,6 +862,7 @@ function Unlock-GitHubIssue
     SupportsShouldProcess,
     DefaultParameterSetName='Elements')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
 param(
     [Parameter(ParameterSetName='Elements')]
     [string] $OwnerName,

--- a/GitHubLabels.ps1
+++ b/GitHubLabels.ps1
@@ -206,6 +206,7 @@ function New-GitHubLabel
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -320,6 +321,7 @@ function Remove-GitHubLabel
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     [Alias('Delete-GitHubLabel')]
     param(
         [Parameter(ParameterSetName='Elements')]
@@ -551,6 +553,7 @@ function Set-GitHubLabel
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -662,6 +665,7 @@ function Add-GitHubIssueLabel
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory, ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -763,6 +767,7 @@ function Set-GitHubIssueLabel
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubMilestones.ps1
+++ b/GitHubMilestones.ps1
@@ -506,6 +506,7 @@ function Remove-GitHubMilestone
         DefaultParameterSetName='Elements')]
     [Alias('Delete-GitHubMilestone')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory, ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubOrganizations.ps1
+++ b/GitHubOrganizations.ps1
@@ -32,6 +32,7 @@ function Get-GitHubOrganizationMember
         Get-GitHubOrganizationMember -OrganizationName PowerShell
 #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     [CmdletBinding(SupportsShouldProcess)]
     param
     (
@@ -96,6 +97,7 @@ function Test-GitHubOrganizationMember
         Test-GitHubOrganizationMember -OrganizationName PowerShell -UserName Octocat
 #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType([bool])]
     param

--- a/GitHubProjectCards.ps1
+++ b/GitHubProjectCards.ps1
@@ -166,8 +166,8 @@ function New-GitHubProjectCard
         SupportsShouldProcess,
         DefaultParameterSetName = 'Note')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
-
         [Parameter(Mandatory)]
         [int64] $Column,
 
@@ -371,6 +371,7 @@ function Remove-GitHubProjectCard
         ConfirmImpact = 'High')]
     [Alias('Delete-GitHubProjectCard')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory)]
         [int64] $Card,

--- a/GitHubProjectColumns.ps1
+++ b/GitHubProjectColumns.ps1
@@ -39,6 +39,7 @@ function Get-GitHubProjectColumn
         SupportsShouldProcess,
         DefaultParameterSetName = 'Project')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory, ParameterSetName = 'Project')]
         [int64] $Project,
@@ -118,6 +119,7 @@ function New-GitHubProjectColumn
     [CmdletBinding(
         SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
 
         [Parameter(Mandatory)]
@@ -190,6 +192,7 @@ function Set-GitHubProjectColumn
     [CmdletBinding(
         SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory)]
         [int64] $Column,
@@ -264,6 +267,7 @@ function Remove-GitHubProjectColumn
         ConfirmImpact = 'High')]
     [Alias('Delete-GitHubProjectColumn')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory)]
         [int64] $Column,
@@ -346,6 +350,7 @@ function Move-GitHubProjectColumn
     [CmdletBinding(
         SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory)]
         [int64] $Column,

--- a/GitHubProjects.ps1
+++ b/GitHubProjects.ps1
@@ -477,6 +477,7 @@ function Remove-GitHubProject
         ConfirmImpact = 'High')]
     [Alias('Delete-GitHubProject')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification = "Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory)]
         [int64] $Project,

--- a/GitHubRepositoryForks.ps1
+++ b/GitHubRepositoryForks.ps1
@@ -47,6 +47,7 @@ function Get-GitHubRepositoryFork
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubRepositoryTraffic.ps1
+++ b/GitHubRepositoryTraffic.ps1
@@ -44,6 +44,7 @@ function Get-GitHubReferrerTraffic
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -128,6 +129,7 @@ function Get-GitHubPathTraffic
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -216,6 +218,7 @@ function Get-GitHubViewTraffic
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -308,6 +311,7 @@ function Get-GitHubCloneTraffic
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubTeams.ps1
+++ b/GitHubTeams.ps1
@@ -48,6 +48,7 @@ function Get-GitHubTeam
         Get-GitHubTeam -OrganizationName PowerShell
 #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     [CmdletBinding(
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]

--- a/GitHubUsers.ps1
+++ b/GitHubUsers.ps1
@@ -57,6 +57,7 @@ function Get-GitHubUser
         SupportsShouldProcess,
         DefaultParameterSetName='ListAndSearch')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='ListAndSearch')]
         [string] $User,
@@ -129,6 +130,7 @@ function Get-GitHubUserContextualInformation
 #>
     [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(Mandatory)]
         [string] $User,

--- a/NugetTools.ps1
+++ b/NugetTools.ps1
@@ -82,9 +82,7 @@ function Get-NugetPackage
 #>
     [CmdletBinding(SupportsShouldProcess)]
     param(
-        [Parameter(
-            Mandatory,
-            ValueFromPipeline)]
+        [Parameter(Mandatory)]
         [string] $PackageName,
 
         [Parameter(Mandatory)]

--- a/PowerShellForGitHub.psd1
+++ b/PowerShellForGitHub.psd1
@@ -92,6 +92,7 @@
         'Get-GitHubUserContextualInformation',
         'Get-GitHubViewTraffic',
         'Group-GitHubIssue',
+        'Group-GitHubPullRequest',
         'Invoke-GHRestMethod',
         'Invoke-GHRestMethodMultipleResult',
         'Lock-GitHubIssue',

--- a/Tests/GitHubProjectCards.tests.ps1
+++ b/Tests/GitHubProjectCards.tests.ps1
@@ -41,7 +41,12 @@ try
             $card = New-GitHubProjectCard -Column $column.id -Note $defaultCard
             $cardArchived = New-GitHubProjectCard -Column $column.id -Note $defaultArchivedCard
             $null = Set-GitHubProjectCard -Card $cardArchived.id -Archive
+
+            # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+            $card = $card
+            $cardArchived = $cardArchived
         }
+
         AfterAll {
             $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false
         }
@@ -85,7 +90,13 @@ try
             $card = New-GitHubProjectCard -Column $column.id -Note $defaultCard
             $cardTwo = New-GitHubProjectCard -Column $column.id -Note $defaultCardTwo
             $cardArchived = New-GitHubProjectCard -Column $column.id -Note $defaultArchivedCard
+
+            # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+            $card = $card
+            $cardTwo = $cardTwo
+            $cardArchived = $cardArchived
         }
+
         AfterAll {
             $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false
         }
@@ -167,7 +178,11 @@ try
         Context 'Create project card with note' {
             BeforeAll {
                 $card = @{id = 0}
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $card = $card
             }
+
             AfterAll {
                 $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false
                 Remove-Variable -Name card
@@ -188,7 +203,11 @@ try
         Context 'Create project card from issue' {
             BeforeAll {
                 $card = @{id = 0}
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $card = $card
             }
+
             AfterAll {
                 $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false
                 Remove-Variable -Name card
@@ -211,6 +230,9 @@ try
         Context 'Remove card' {
             BeforeAll {
                 $card = New-GitHubProjectCard -Column $column.id -Note $defaultCard
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $card = $card
             }
 
             $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false

--- a/Tests/GitHubProjectColumns.tests.ps1
+++ b/Tests/GitHubProjectColumns.tests.ps1
@@ -27,7 +27,11 @@ try
     Describe 'Getting Project Columns' {
         BeforeAll {
             $column = New-GitHubProjectColumn -Project $project.id -Name $defaultColumn
+
+            # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+            $column = $column
         }
+
         AfterAll {
             $null = Remove-GitHubProjectColumn -Column $column.id -Confirm:$false
         }
@@ -48,7 +52,12 @@ try
         BeforeAll {
             $column = New-GitHubProjectColumn -Project $project.id -Name $defaultColumn
             $columntwo = New-GitHubProjectColumn -Project $project.id -Name $defaultColumnTwo
+
+            # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+            $column = $column
+            $columnTwo = $columnTwo
         }
+
         AfterAll {
             $null = Remove-GitHubProjectColumn -Column $column.id -Confirm:$false
             $null = Remove-GitHubProjectColumn -Column $columntwo.id -Confirm:$false
@@ -96,7 +105,11 @@ try
         Context 'Create project column' {
             BeforeAll {
                 $column = @{id = 0}
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $column = $column
             }
+
             AfterAll {
                 $null = Remove-GitHubProjectColumn -Column $column.id -Confirm:$false
                 Remove-Variable -Name column
@@ -119,6 +132,9 @@ try
         Context 'Remove project column' {
             BeforeAll {
                 $column = New-GitHubProjectColumn -Project $project.id -Name $defaultColumn
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $column = $column
             }
 
             $null = Remove-GitHubProjectColumn -Column $column.id -Confirm:$false

--- a/Tests/GitHubProjects.tests.ps1
+++ b/Tests/GitHubProjects.tests.ps1
@@ -35,11 +35,14 @@ try
     $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
 
     Describe 'Getting Project' {
-
         Context 'Get User projects' {
             BeforeAll {
                 $project = New-GitHubProject -UserProject -Name $defaultUserProject -Description $defaultUserProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -61,7 +64,11 @@ try
         Context 'Get Organization projects' {
             BeforeAll {
                 $project = New-GitHubProject -OrganizationName $script:organizationName -Name $defaultOrgProject -Description $defaultOrgProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -83,7 +90,11 @@ try
         Context 'Get Repo projects' {
             BeforeAll {
                 $project = New-GitHubProject -OwnerName $script:ownerName -RepositoryName $repo.name -Name $defaultRepoProject -Description $defaultRepoProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -106,7 +117,11 @@ try
             BeforeAll {
                 $project = New-GitHubProject -OwnerName $script:ownerName -RepositoryName $repo.name -Name $defaultProjectClosed -Description $defaultProjectClosedDesc
                 $null = Set-GitHubProject -Project $project.id -State Closed
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -134,7 +149,11 @@ try
         Context 'Modify User projects' {
             BeforeAll {
                 $project = New-GitHubProject -UserProject -Name $defaultUserProject -Description $defaultUserProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -157,7 +176,11 @@ try
         Context 'Modify Organization projects' {
             BeforeAll {
                 $project = New-GitHubProject -OrganizationName $script:organizationName -Name $defaultOrgProject -Description $defaultOrgProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -189,7 +212,11 @@ try
         Context 'Modify Repo projects' {
             BeforeAll {
                 $project = New-GitHubProject -OwnerName $script:ownerName -RepositoryName $repo.name -Name $defaultRepoProject -Description $defaultRepoProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
@@ -214,7 +241,11 @@ try
         Context 'Create User projects' {
             BeforeAll {
                 $project = @{id = 0}
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
                 Remove-Variable project
@@ -238,7 +269,11 @@ try
         Context 'Create Organization projects' {
             BeforeAll {
                 $project = @{id = 0}
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
                 Remove-Variable project
@@ -262,7 +297,11 @@ try
         Context 'Create Repo projects' {
             BeforeAll {
                 $project = @{id = 0}
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
+
             AfterAll {
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
                 Remove-Variable project
@@ -288,6 +327,9 @@ try
         Context 'Remove User projects' {
             BeforeAll {
                 $project = New-GitHubProject -UserProject -Name $defaultUserProject -Description $defaultUserProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
 
             $null = Remove-GitHubProject -Project $project.id -Confirm:$false
@@ -299,6 +341,9 @@ try
         Context 'Remove Organization projects' {
             BeforeAll {
                 $project = New-GitHubProject -OrganizationName $script:organizationName -Name $defaultOrgProject -Description $defaultOrgProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
 
             $null = Remove-GitHubProject -Project $project.id -Confirm:$false
@@ -310,6 +355,9 @@ try
         Context 'Remove Repo projects' {
             BeforeAll {
                 $project = New-GitHubProject -OwnerName $script:ownerName -RepositoryName $repo.name -Name $defaultRepoProject -Description $defaultRepoProjectDesc
+
+                # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
+                $project = $project
             }
 
             $null = Remove-GitHubProject -Project $project.id -Confirm:$false


### PR DESCRIPTION
Somehow a number of PSScriptAnalyzer issues have snuck in over time.  This fixes them all.

The main PSScriptAnalyzer issues needing to be fixed were:
 * `PSReviewUnusedParameter` - This one came up a lot due to our heavy
    usage of `Resolve-RepositoryElements` and `Resolve-ParameterWithDefaultConfigurationValue`
    which both end up referencing their parameters by grabbing them off
    the stack.  That means that `NoStatus` and `Uri` are frequently
    never directly referenced.  So, exceptions were added.  There were
    two cases (in GitHubAnalytics) where there was a false positive due
    to PowerShell/PSScriptAnalyzer#1472

 * `PSUseProcessBlockForPipelineCommand` - We had a number of functions
   that took pipeline input, but didn't actuall use the `process` block.
   This actually caught a bug with `Group-GitHubIssue` and
   `Group-GitHubPullRequest`.  Added correct `process` block usage for
   most of the functions, but removed pipeline support for those where
   it didn't actually make sense anymore.

 * `PSUseDeclaredVarsMoreThanAssignments` - These are false positives
   in the Pester tests due to the usage of `BeforeAll`.  There wasn't
   an obvious way to use `SuppressMessageAttribute` in the Pester test,
   so I used a hacky workaround to "use" the variable in the `BeforeAll`
   block.  I could have added the suppression to the top of the file,
   but I still want to catch real issues in those files later.

 * `PSAvoidOverwritingBuiltInCmdlets` - It turns out that there's a bug
   with PSDesiredStateConfiguration in PS Core 6.1.0 where it was exporting
   internal functions.  This was thus a false-postive flag for Write-Log.
   See PowerShell/PowerShell#7209 for more info.

Also, it turns out that `Group-GitHubPullRequest` hadn't actually been
exported, so I fixed that too.