### PR TITLE
Fix named branch querying in Get-GitHubRepositoryBranch

### DIFF
--- a/GitHubBranches.ps1
+++ b/GitHubBranches.ps1
@@ -89,7 +89,7 @@ function Get-GitHubRepositoryBranch
         'RepositoryName' = (Get-PiiSafeString -PlainText $RepositoryName)
     }
 
-    $uriFragment = "repos/$OwnerName/$RepositoryName/branches`?"
+    $uriFragment = "repos/$OwnerName/$RepositoryName/branches"
     if (-not [String]::IsNullOrEmpty($Name)) { $uriFragment = $uriFragment + "/$Name" }
 
     $getParams = @()


### PR DESCRIPTION
We erroneously were putting a question mark in the middle of the
URI fragment when a branch name was being specified.

Resolves #187