### PR TITLE
Exception in New-GitHubRepository when specifying TeamId

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -139,7 +139,7 @@ function New-GitHubRepository
         $uriFragment = "orgs/$OrganizationName/repos"
     }
 
-    if ($PSBoundParameters.ContainsKey('TeamId') -and (-not $PSBoundParameters.Contains('OrganizationName')))
+    if ($PSBoundParameters.ContainsKey('TeamId') -and (-not $PSBoundParameters.ContainsKey('OrganizationName')))
     {
         $message = 'TeamId may only be specified when creating a repository under an organization.'
         Write-Log -Message $message -Level Error


### PR DESCRIPTION
Incorrectly used `$PSBoundParameters.Contains` instead of
`$PSBoundParameters.ContainsKey`.

Resolves #195