### PR TITLE
UpdateCheck must handle when module is newer than published version

### DIFF
--- a/UpdateCheck.ps1
+++ b/UpdateCheck.ps1
@@ -81,7 +81,11 @@ function Invoke-UpdateCheck
                 $script:HasLatestVersion = $latestVersion -eq $moduleVersion
                 if ($script:HasLatestVersion)
                 {
-                    Write-Log "[$moduleName] update check complete.  Running latest version: $($latestVersion.ToString())" -Level Verbose
+                    Write-Log "[$moduleName] update check complete.  Running latest version: $latestVersion" -Level Verbose
+                }
+                elseif ($moduleVersion -gt $latestVersion)
+                {
+                    Write-Log "[$moduleName] update check complete.  This version ($moduleVersion) is newer than the latest published version ($latestVersion)." -Level Verbose
                 }
                 else
                 {


### PR DESCRIPTION
Publishing a new version to PowerShellGallery happens a few hours after
the version is updated in GitHub.  This edge-case meant that someone
in this state would have been told that the older published version was
newer than the version that they were currently using.