### PR TITLE
Speed up Pester tests by using -NoStatus

### DIFF
--- a/Tests/Common.ps1
+++ b/Tests/Common.ps1
@@ -89,6 +89,7 @@ function Initialize-CommonTestSetup
     Reset-GitHubConfiguration
     Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
     Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
+    Set-GitHubConfiguration -DefaultNoStatus # Status corrupts the raw CI logs for Linux and Mac, and makes runs take slightly longer.
 }
 
 Initialize-CommonTestSetup


### PR DESCRIPTION
Suppressing Status (e.g. using `-NoStatus`) reduces the overall runtime of the UT's across all 3 platforms (Windows, Linux, Mac) by 25-30 min.  It also has the side-effect of improving the readability of the raw logs on CI for Linux and Mac.

[Most recent run](https://dev.azure.com/ms/PowerShellForGitHub/_build/results?buildId=84315) without this change: 1h 19m
[Run with this change](https://dev.azure.com/ms/PowerShellForGitHub/_build/results?buildId=84357) without this change: 54m

Resolves #206