### PR TITLE
Disable the module update check during Pester Tests

### DIFF
--- a/Tests/Common.ps1
+++ b/Tests/Common.ps1
@@ -90,6 +90,7 @@ function Initialize-CommonTestSetup
     Set-GitHubConfiguration -DisableTelemetry # We don't want UT's to impact telemetry
     Set-GitHubConfiguration -LogRequestBody # Make it easier to debug UT failures
     Set-GitHubConfiguration -DefaultNoStatus # Status corrupts the raw CI logs for Linux and Mac, and makes runs take slightly longer.
+    Set-GitHubConfiguration -DisableUpdateCheck # The update check is unnecessary during tests.
 }
 
 Initialize-CommonTestSetup


### PR DESCRIPTION
We don't get any value from this update check when running the tests.