### PR TITLE
Set-GitHubRepositoryTopic: Fix Exception When Clear 'Parameter' is Specified

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -1033,12 +1033,18 @@ function Set-GitHubRepositoryTopic
         'Clear' = $PSBoundParameters.ContainsKey('Clear')
     }
 
-    $description = "Replacing topics in $RepositoryName"
-    if ($Clear) { $description = "Clearing topics in $RepositoryName" }
+    if ($Clear)
+    {
+        $description = "Clearing topics in $RepositoryName"
+        $Name=@()
+    }
+    else
+    {
+        $description = "Replacing topics in $RepositoryName"
+    }
 
-    $names = @($Name)
     $hashBody = @{
-        'names' = $names
+        'names' = $Name
     }
 
     $params = @{

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -1036,7 +1036,7 @@ function Set-GitHubRepositoryTopic
     if ($Clear)
     {
         $description = "Clearing topics in $RepositoryName"
-        $Name=@()
+        $Name = @()
     }
     else
     {


### PR DESCRIPTION
#### Description

This PR fixes the exception in the `Set-GithubRepositoryTopic` function when the `Clear` parameter is specified.

#### Issues Fixed

- Fixes #215 

#### References

https://developer.github.com/v3/repos/#replace-all-repository-topics - Send an empty array ([]) to clear all topics from the repository.

#### Checklist
<!--
    To aid reviewers, please take the time to run through the below checklist
    and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that you have completed.
    If a task doesn't apply, add a strikethrough by putting "~~" before and after the text.
-->
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] Comment-based help added/updated, including examples.
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis)
is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).
- [ ] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).
- [ ] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).
- [ ] If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)
