### PR TITLE
Adding -Force switch to ConfirmImpact=High functions

### DIFF
--- a/GitHubAssignees.ps1
+++ b/GitHubAssignees.ps1
@@ -324,6 +324,9 @@ function Remove-GithubAssignee
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee $assignees
 
@@ -333,6 +336,11 @@ function Remove-GithubAssignee
         Remove-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee $assignees -Confirm:$false
 
         Lists the available assignees for issues from the Microsoft\PowerShellForGitHub project. Will not prompt for confirmation, as -Confirm:$false was specified.
+
+    .EXAMPLE
+        Remove-GithubAssignee -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Assignee $assignees -Force
+
+        Lists the available assignees for issues from the Microsoft\PowerShellForGitHub project. Will not prompt for confirmation, as -Force was specified.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -359,7 +367,9 @@ function Remove-GithubAssignee
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -379,7 +389,7 @@ function Remove-GithubAssignee
         'assignees' = $Assignee
     }
 
-    if ($PSCmdlet.ShouldProcess($Assignee -join ', ', "Remove assignee(s)"))
+    if ($Force -or $PSCmdlet.ShouldProcess($Assignee -join ', ', "Remove assignee(s)"))
     {
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/assignees"

--- a/GitHubComments.ps1
+++ b/GitHubComments.ps1
@@ -448,6 +448,9 @@ function Remove-GitHubComment
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1
 
@@ -455,6 +458,11 @@ function Remove-GitHubComment
 
     .EXAMPLE
         Remove-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1 -Confirm:$false
+
+        Deletes a Github comment from the Microsoft\PowerShellForGitHub project without prompting confirmation.
+
+    .EXAMPLE
+        Remove-GitHubComment -OwnerName Microsoft -RepositoryName PowerShellForGitHub -CommentID 1 -Force
 
         Deletes a Github comment from the Microsoft\PowerShellForGitHub project without prompting confirmation.
 #>
@@ -481,7 +489,9 @@ function Remove-GitHubComment
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -496,7 +506,7 @@ function Remove-GitHubComment
         'CommentID' =  (Get-PiiSafeString -PlainText $CommentID)
     }
 
-    if ($PSCmdlet.ShouldProcess($CommentID, "Remove comment"))
+    if ($Force -or $PSCmdlet.ShouldProcess($CommentID, "Remove comment"))
     {
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/comments/$CommentID"

--- a/GitHubLabels.ps1
+++ b/GitHubLabels.ps1
@@ -312,6 +312,9 @@ function Remove-GitHubLabel
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel
 
@@ -321,6 +324,11 @@ function Remove-GitHubLabel
         Remove-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Confirm:$false
 
         Removes the label called "TestLabel" from the PowerShellForGitHub project. Will not prompt for confirmation, as -Confirm:$false was specified.
+
+    .EXAMPLE
+        Remove-GitHubLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Force
+
+        Removes the label called "TestLabel" from the PowerShellForGitHub project. Will not prompt for confirmation, as -Force was specified.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -347,7 +355,9 @@ function Remove-GitHubLabel
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -361,7 +371,7 @@ function Remove-GitHubLabel
         'RepositoryName' = (Get-PiiSafeString -PlainText $RepositoryName)
     }
 
-    if ($PSCmdlet.ShouldProcess($Name, "Remove label"))
+    if ($Force -or $PSCmdlet.ShouldProcess($Name, "Remove label"))
     {
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/labels/$Name"
@@ -869,6 +879,9 @@ function Remove-GitHubIssueLabel
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubIssueLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Issue 1
 
@@ -878,6 +891,11 @@ function Remove-GitHubIssueLabel
         Remove-GitHubIssueLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Issue 1 -Confirm:$false
 
         Removes the label called "TestLabel" from issue 1 in the PowerShellForGitHub project. Will not prompt for confirmation, as -Confirm:$false was specified.
+
+    .EXAMPLE
+        Remove-GitHubIssueLabel -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Name TestLabel -Issue 1 -Force
+
+        Removes the label called "TestLabel" from issue 1 in the PowerShellForGitHub project. Will not prompt for confirmation, as -Force was specified.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -903,7 +921,9 @@ function Remove-GitHubIssueLabel
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -928,7 +948,7 @@ function Remove-GitHubIssueLabel
         $description = "Deleting all labels from issue $Issue in $RepositoryName"
     }
 
-    if ($PSCmdlet.ShouldProcess($Name, "Remove label"))
+    if ($Force -or $PSCmdlet.ShouldProcess($Name, "Remove label"))
     {
         $params = @{
             'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues/$Issue/labels/$Name"

--- a/GitHubMilestones.ps1
+++ b/GitHubMilestones.ps1
@@ -496,6 +496,9 @@ function Remove-GitHubMilestone
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1
 
@@ -505,6 +508,11 @@ function Remove-GitHubMilestone
         Remove-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1 -Confirm:$false
 
         Deletes a Github milestone from the Microsoft\PowerShellForGitHub project. Will not prompt for confirmation, as -Confirm:$false was specified.
+
+    .EXAMPLE
+        Remove-GitHubMilestone -OwnerName Microsoft -RepositoryName PowerShellForGitHub -Milestone 1 -Force
+
+        Deletes a Github milestone from the Microsoft\PowerShellForGitHub project. Will not prompt for confirmation, as -Force was specified.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -528,7 +536,9 @@ function Remove-GitHubMilestone
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -543,7 +553,7 @@ function Remove-GitHubMilestone
         'Milestone' =  (Get-PiiSafeString -PlainText $Milestone)
     }
 
-    if ($PSCmdlet.ShouldProcess($Milestone, "Remove milestone"))
+    if ($Force -or $PSCmdlet.ShouldProcess($Milestone, "Remove milestone"))
     {
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/milestones/$Milestone"

--- a/GitHubProjectCards.ps1
+++ b/GitHubProjectCards.ps1
@@ -356,6 +356,9 @@ function Remove-GitHubProjectCard
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubProjectCard -Card 999999
 
@@ -363,6 +366,11 @@ function Remove-GitHubProjectCard
 
     .EXAMPLE
         Remove-GitHubProjectCard -Card 999999 -Confirm:$False
+
+        Remove project card with ID 999999 without prompting for confirmation.
+
+    .EXAMPLE
+        Remove-GitHubProjectCard -Card 999999 -Force
 
         Remove project card with ID 999999 without prompting for confirmation.
 #>
@@ -377,7 +385,9 @@ function Remove-GitHubProjectCard
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -387,7 +397,7 @@ function Remove-GitHubProjectCard
     $uriFragment = "/projects/columns/cards/$Card"
     $description = "Deleting card $Card"
 
-    if ($PSCmdlet.ShouldProcess($Card, "Remove card"))
+    if ($Force -or $PSCmdlet.ShouldProcess($Card, "Remove card"))
     {
         $params = @{
             'UriFragment' = $uriFragment

--- a/GitHubProjectColumns.ps1
+++ b/GitHubProjectColumns.ps1
@@ -252,6 +252,9 @@ function Remove-GitHubProjectColumn
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubProjectColumn -Column 999999
 
@@ -259,6 +262,11 @@ function Remove-GitHubProjectColumn
 
     .EXAMPLE
         Remove-GitHubProjectColumn -Column 999999 -Confirm:$False
+
+        Removes the project column with ID 999999 without prompting for confirmation.
+
+    .EXAMPLE
+        Remove-GitHubProjectColumn -Column 999999 -Force
 
         Removes the project column with ID 999999 without prompting for confirmation.
 #>
@@ -273,7 +281,9 @@ function Remove-GitHubProjectColumn
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -283,7 +293,7 @@ function Remove-GitHubProjectColumn
     $uriFragment = "/projects/columns/$Column"
     $description = "Deleting column $Column"
 
-    if ($PSCmdlet.ShouldProcess($Column, "Remove column"))
+    if ($Force -or $PSCmdlet.ShouldProcess($Column, "Remove column"))
     {
         $params = @{
             'UriFragment' = $uriFragment

--- a/GitHubProjects.ps1
+++ b/GitHubProjects.ps1
@@ -460,6 +460,9 @@ function Remove-GitHubProject
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubProject -Project 4387531
 
@@ -467,6 +470,11 @@ function Remove-GitHubProject
 
     .EXAMPLE
         Remove-GitHubProject -Project 4387531 -Confirm:$false
+
+        Remove project with ID '4387531' without prompting for confirmation.
+
+    .EXAMPLE
+        Remove-GitHubProject -Project 4387531 -Force
 
         Remove project with ID '4387531' without prompting for confirmation.
 
@@ -488,7 +496,9 @@ function Remove-GitHubProject
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog
@@ -498,7 +508,7 @@ function Remove-GitHubProject
     $uriFragment = "projects/$Project"
     $description = "Deleting project $Project"
 
-    if ($PSCmdlet.ShouldProcess($project, "Remove project"))
+    if ($Force -or $PSCmdlet.ShouldProcess($project, "Remove project"))
     {
         $params = @{
             'UriFragment' = $uriFragment

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -212,6 +212,9 @@ function Remove-GitHubRepository
         the background, enabling the command prompt to provide status information.
         If not supplied here, the DefaultNoStatus configuration property value will be used.
 
+    .PARAMETER Force
+        If this switch is specified, you will not be prompted for confirmation of command execution.
+
     .EXAMPLE
         Remove-GitHubRepository -OwnerName You -RepositoryName YourRepoToDelete
 
@@ -220,6 +223,11 @@ function Remove-GitHubRepository
 
     .EXAMPLE
         Remove-GitHubRepository -Uri https://github.com/You/YourRepoToDelete -Confirm:$false
+
+        Remove repository with the given URI, without prompting for confirmation.
+
+    .EXAMPLE
+        Remove-GitHubRepository -Uri https://github.com/You/YourRepoToDelete -Force
 
         Remove repository with the given URI, without prompting for confirmation.
 #>
@@ -242,7 +250,9 @@ function Remove-GitHubRepository
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     Write-InvocationLog -Invocation $MyInvocation
@@ -255,7 +265,7 @@ function Remove-GitHubRepository
         'OwnerName' = (Get-PiiSafeString -PlainText $OwnerName)
         'RepositoryName' = (Get-PiiSafeString -PlainText $RepositoryName)
     }
-    if ($PSCmdlet.ShouldProcess($RepositoryName, "Remove repository"))
+    if ($Force -or $PSCmdlet.ShouldProcess($RepositoryName, "Remove repository"))
     {
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName"
@@ -625,6 +635,15 @@ function Rename-GitHubRepository
     .EXAMPLE
         New-GitHubRepositoryFork -Uri https://github.com/octocat/hello-world | Foreach-Object {$_ | Rename-GitHubRepository -NewName "$($_.name)_fork"}
         Fork the `hello-world` repository from the user 'octocat', and then rename the newly forked repository by appending '_fork'.
+
+    .EXAMPLE
+        Rename-GitHubRepository -Uri https://github.com/octocat/hello-world -NewName hello-again-world -Confirm:$false
+
+        Rename the repository at https://github.com/octocat/hello-world to https://github.com/octocat/hello-again-world without prompting for confirmation.
+
+    .EXAMPLE
+        Rename-GitHubRepository -Uri https://github.com/octocat/hello-world -NewName hello-again-world -Force
+        Rename the repository at https://github.com/octocat/hello-world to https://github.com/octocat/hello-again-world without prompting for confirmation.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
@@ -649,13 +668,15 @@ function Rename-GitHubRepository
 
         [string] $AccessToken,
 
-        [switch] $NoStatus
+        [switch] $NoStatus,
+
+        [switch] $Force
     )
 
     process
     {
         $repositoryInfoForDisplayMessage = if ($PSCmdlet.ParameterSetName -eq "Uri") { $Uri } else { $OwnerName, $RepositoryName -join "/" }
-        if ($PSCmdlet.ShouldProcess($repositoryInfoForDisplayMessage, "Rename repository to '$NewName'"))
+        if ($Force -or $PSCmdlet.ShouldProcess($repositoryInfoForDisplayMessage, "Rename repository to '$NewName'"))
         {
             Write-InvocationLog -Invocation $MyInvocation
             $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters

--- a/Tests/GitHubLabels.tests.ps1
+++ b/Tests/GitHubLabels.tests.ps1
@@ -267,8 +267,8 @@ try
 
             Context 'For removing individual issues'{
                 Remove-GitHubIssueLabel -OwnerName $ownerName -RepositoryName $repositoryName -Name "discussion" -Issue $issue.number -Confirm:$false
-                Remove-GitHubIssueLabel -OwnerName $ownerName -RepositoryName $repositoryName -Name "question" -Issue $issue.number -Confirm:$false
-                Remove-GitHubIssueLabel -OwnerName $ownerName -RepositoryName $repositoryName -Name "bug" -Issue $issue.number -Confirm:$false
+                Remove-GitHubIssueLabel -OwnerName $ownerName -RepositoryName $repositoryName -Name "question" -Issue $issue.number -Force
+                Remove-GitHubIssueLabel -OwnerName $ownerName -RepositoryName $repositoryName -Name "bug" -Issue $issue.number -Confirm:$false -Force
                 $labelIssues = @(Get-GitHubLabel -OwnerName $ownerName -RepositoryName $repositoryName -Issue $issue.number)
 
                 It 'Should have removed three labels from the issue' {

--- a/Tests/GitHubProjectCards.tests.ps1
+++ b/Tests/GitHubProjectCards.tests.ps1
@@ -98,7 +98,7 @@ try
         }
 
         AfterAll {
-            $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false
+            $null = Remove-GitHubProjectCard -Card $card.id -Force
         }
 
         Context 'Modify card note' {
@@ -209,7 +209,7 @@ try
             }
 
             AfterAll {
-                $null = Remove-GitHubProjectCard -Card $card.id -Confirm:$false
+                $null = Remove-GitHubProjectCard -Card $card.id -Force
                 Remove-Variable -Name card
             }
 

--- a/Tests/GitHubProjectColumns.tests.ps1
+++ b/Tests/GitHubProjectColumns.tests.ps1
@@ -119,7 +119,7 @@ try
             }
 
             AfterAll {
-                $null = Remove-GitHubProjectColumn -Column $column.id -Confirm:$false
+                $null = Remove-GitHubProjectColumn -Column $column.id -Force
                 Remove-Variable -Name column
             }
 

--- a/Tests/GitHubProjects.tests.ps1
+++ b/Tests/GitHubProjects.tests.ps1
@@ -348,7 +348,7 @@ try
                 $project = $project
             }
 
-            $null = Remove-GitHubProject -Project $project.id -Confirm:$false
+            $null = Remove-GitHubProject -Project $project.id -Force
             It 'Project should be removed' {
                 {Get-GitHubProject -Project $project.id} | Should Throw
             }
@@ -362,7 +362,7 @@ try
                 $project = $project
             }
 
-            $null = Remove-GitHubProject -Project $project.id -Confirm:$false
+            $null = Remove-GitHubProject -Project $project.id -Force
             It 'Project should be removed' {
                 {Get-GitHubProject -Project $project.id} | Should Throw
             }

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -154,15 +154,20 @@ try
     Describe 'Deleting repositories' {
 
         Context -Name 'For deleting a repository' -Fixture {
-            BeforeAll -ScriptBlock {
+            BeforeEach -ScriptBlock {
                 $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -Description $defaultRepoDesc -AutoInit
 
                 # Avoid PSScriptAnalyzer PSUseDeclaredVarsMoreThanAssignments
                 $repo = $repo
             }
 
-            It 'Should get no content' {
+            It 'Should get no content using -Confirm:$false' {
                 Remove-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -Confirm:$false
+                { Get-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name } | Should -Throw
+            }
+
+            It 'Should get no content using -Force' {
+                Remove-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -Force
                 { Get-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name } | Should -Throw
             }
         }
@@ -181,7 +186,7 @@ try
             }
 
             It "Should have the expected new repository name - by URI" {
-                $renamedRepo = $repo | Rename-GitHubRepository -NewName $newRepoName -Confirm:$false
+                $renamedRepo = $repo | Rename-GitHubRepository -NewName $newRepoName -Force
                 $renamedRepo.name | Should -Be $newRepoName
             }
 
@@ -272,7 +277,7 @@ try
             }
 
             AfterAll -ScriptBlock {
-                Remove-GitHubRepository -Uri $repo.svn_url -Confirm:$false
+                Remove-GitHubRepository -Uri $repo.svn_url -Force
             }
         }
     }


### PR DESCRIPTION
#### Description
Adding -Force switch to ConfirmImpact=High functions and tests

#### Issues Fixed
Fixes #218 

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] Comment-based help added/updated, including examples.
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis)
is reporting back clean.
- [ ] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).
- [ ] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).
- [ ] If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)
