### PR TITLE
PowerShellForGitHub: Disable Progress Bar for Invoke-WebRequest

### DIFF
--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -223,8 +223,15 @@ function Invoke-GHRestMethod
                 }
             }
 
+            # Temporarily Disable Progress Bar during Invoke-WebRequest
+            $tempProgressPreference = $ProgressPreference
+            $ProgressPreference = 'SilentlyContinue'
+
             [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
             $result = Invoke-WebRequest @params
+
+            $progressPreference = $tempProgressPreference
+
             if ($Method -eq 'Delete')
             {
                 Write-Log -Message "Successfully removed." -Level Verbose
@@ -265,8 +272,14 @@ function Invoke-GHRestMethod
 
                 try
                 {
+                    # Temporarily Disable Progress Bar during Invoke-WebRequest
+                    $tempProgressPreference = $ProgressPreference
+                    $ProgressPreference = 'SilentlyContinue'
+
                     [Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12
                     Invoke-WebRequest @params
+
+                    $progressPreference = $tempProgressPreference
                 }
                 catch [System.Net.WebException]
                 {


### PR DESCRIPTION
#### Description

This PR disables the PowerShell progress bar for the `Invoke-WebRequest` cmdlet calls in the `Invoke-GHRestMethod` function due to known performance issues in PowerShell 5.1.

#### Issues Fixed

- Fixes #227 

#### References

[Progress bar can significantly impact cmdlet performance.](https://github.com/PowerShell/PowerShell/issues/2138)

#### Checklist
<!--
    To aid reviewers, please take the time to run through the below checklist
    and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that you have completed.
    If a task doesn't apply, add a strikethrough by putting "~~" before and after the text.
-->
- [ ] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] Comment-based help added/updated, including examples.
- [ ] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis)
is reporting back clean.
- [ ] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).
- [ ] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).
- [ ] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).
- [ ] If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)
