### PR TITLE
Re-enable parallel platform execution in CI build

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -26,21 +26,31 @@ jobs:
   - template: ./templates/verify-testConfigSettingsHash.yaml
   - template: ./templates/run-staticAnalysis.yaml
   - template: ./templates/run-unitTests.yaml
+    parameters:
+      gitHubAccessToken: $(WindowsCIGitHubAccessToken)
+      gitHubOwnerName: $(WindowsCIGitHubOwnerName)
+      gitHubOrganizationName: $(WindowsCIGitHubOrganizationName)
 
 - job: Linux
   pool:
     vmImage: 'ubuntu-16.04'
-  dependsOn: Windows # Run in series instead of parallel because the UT's are modifying the same shared state
   steps:
   - template: ./templates/verify-testConfigSettingsHash.yaml
   - template: ./templates/run-staticAnalysis.yaml
   - template: ./templates/run-unitTests.yaml
+    parameters:
+      gitHubAccessToken: $(LinuxCIAccessToken)
+      gitHubOwnerName: $(LinuxCIGitHubOwnerName)
+      gitHubOrganizationName: $(LinuxCIGitHubOrganizationName)
 
 - job: macOS
   pool:
     vmImage: 'macOS-10.14'
-  dependsOn: Linux # Run in series instead of parallel because the UT's are modifying the same shared state
   steps:
   - template: ./templates/verify-testConfigSettingsHash.yaml
   - template: ./templates/run-staticAnalysis.yaml
   - template: ./templates/run-unitTests.yaml
+    parameters:
+      gitHubAccessToken: $(MacCIAccessToken)
+      gitHubOwnerName: $(MacCIGitHubOwnerName)
+      gitHubOrganizationName: $(MacCIGitHubOrganizationName)

--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -31,6 +31,10 @@ jobs:
   steps:
   - template: ./templates/run-staticAnalysis.yaml
   - template: ./templates/run-unitTests.yaml
+    parameters:
+      gitHubAccessToken: $(GitHubAccessToken)
+      gitHubOwnerName: $(GitHubOwnerName)
+      gitHubOrganizationName: $(GitHubOrganizationName)
 
 - job: Release
   dependsOn: Validate

--- a/build/pipelines/templates/run-unitTests.yaml
+++ b/build/pipelines/templates/run-unitTests.yaml
@@ -13,6 +13,14 @@
 #  3. GitHubOrganizationName - The default "organization" that will be used for tests.
 #--------------------------------------------------------------------------------------------------
 
+parameters:
+- name: 'gitHubAccessToken'
+  type: string
+- name: 'gitHubOwnerName'
+  type: string
+- name: 'gitHubOrganizationName'
+  type: string
+
 steps:
   - powershell: |
       Install-Module -Name Pester -Repository PSGallery -Scope CurrentUser -AllowClobber -SkipPublisherCheck -RequiredVersion 4.10.1 -Force -Verbose
@@ -24,9 +32,9 @@ steps:
     workingDirectory: '$(System.DefaultWorkingDirectory)'
     displayName: 'Run Unit Tests via Pester'
     env:
-      ciAccessToken: $(GitHubAccessToken)
-      ciOwnerName: $(GitHubOwnerName)
-      ciOrganizationName: $(GitHubOrganizationName)
+      ciAccessToken: ${{ parameters.gitHubAccessToken }}
+      ciOwnerName: ${{ parameters.gitHubOwnerName }}
+      ciOrganizationName: ${{ parameters.gitHubOrganizationName }}
 
   - task: PublishTestResults@2
     displayName: 'Publish Test Results'


### PR DESCRIPTION
In a previous commit (b4439f4a6b12f89d755851b313eff0e9ea0b3ab5), the three platforms in the CI pipeline (Windows, Linux, and Mac) were modified to execute serially since they were all operating against the same shared test account, which caused the Pester tests to operate unstabily.

I've now created multiple test accounts so that that each platform can operate in isolation of each other.  I've updated the UT template to accept parameter input, and modified the CI (and release) pipeline to reference a different AccessToken/OwnerName/OrganizationName based on which platform is being targeted.