### PR TITLE
Improve performance of Get-GitHubContent

### DIFF
--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -351,8 +351,9 @@ function Invoke-GHRestMethod
             # In the case of getting raw content from the repo, we'll end up with a large object/byte
             # array which isn't convertible to a smarter object, but by _trying_ we'll end up wasting
             # a lot of time.  Let's optimize here by not bothering to send in something that we
-            # know is definitely not convertible.
-            if ($finalResult -isnot [Object[]])
+            # know is definitely not convertible ([int32] on PS5, [long] on PS7).
+            if (($finalResult -isnot [Object[]]) -or
+                (($finalResult.Count -gt 0) -and ($finalResult[0] -isnot [int]) -and ($finalResult[0] -isnot [long])))
             {
                 $finalResult = ConvertTo-SmarterObject -InputObject $finalResult
             }
@@ -907,7 +908,13 @@ filter ConvertTo-SmarterObject
         return $null
     }
 
-    if ($InputObject -is [System.Collections.IList])
+    if (($InputObject -is [int]) -or ($InputObject -is [long]))
+    {
+        # In some instances, an int/long was being seen as a [PSCustomObject].
+        # This attempts to short-circuit extra work we would have done had that happened.
+        Write-Output -InputObject $InputObject
+    }
+    elseif ($InputObject -is [System.Collections.IList])
     {
         $InputObject |
             ConvertTo-SmarterObject |

--- a/Tests/GitHubAnalytics.tests.ps1
+++ b/Tests/GitHubAnalytics.tests.ps1
@@ -28,7 +28,6 @@ try
             for ($i = 0; $i -lt 4; $i++)
             {
                 $newIssues += New-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Title ([guid]::NewGuid().Guid)
-                Start-Sleep -Seconds 5
             }
 
             $newIssues[0] = Update-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[0].number -State Closed


### PR DESCRIPTION
## Description
The call to `ConvertTo-SmarterObject` was adding a significant amount of time to the execution of Get-GitHubContent.

```powershell
    Set-GitHubConfiguration -DisableSmarterObjects:$false
    Measure-Command { $c = Get-GitHubContent -OwnerName microsoft -RepositoryName PowerShellForGitHub -Path README.md }
    # This averages to be around 1.2 seconds

    Set-GitHubConfiguration -DisableSmarterObjects:$true
    Measure-Command { $c = Get-GitHubContent -OwnerName microsoft -RepositoryName PowerShellForGitHub -Path README.md }
    # This averages to be around 14 seconds
```

The reasoning behind this was that the return of `Invoke-WebRequest` for this repo's `README.md` was an array of [int32] that contained 22,000+ entries (one byte per entry).  Because the array was created by `ConverFrom-Json`, each `[int32]` was also an `[object]`, which meant that it was considered a `[PSCustomObject]` inside of `ConverTo-SmarterObject`, which caused it to do a lot of unnecessary work. Piping in 22,000 objects and doing all of that unnecessary work to end up just calling `Write-Output` on the original value took a _lot_ of time.

The fix here was to skip trying to convert the result to a smarter object if it wasn't going to be a convertible object in the first place.

I also added in protection directly to `ConverTo-SmarterObject` as well.  It made things better than the current runtime, but still twice as slow as not calling it in the first place (average runtime of above command was 3.5 seconds when we allowed it to go into the command and then do nothing).

This doesn't end up saving much time with the execution of `Tests/GitHubContents.tests.ps1` because the file being returned is so small, but this should have some nice user experience improvements in practical usage.

#### Issues Fixed
None

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
