### PR TITLE
CI: Report full stack trace if ScriptAnalyzer throws an error and improve ScriptAnalyzer installation to not skip publisher and check and not allow clobber

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -486,6 +486,7 @@ Thank you to all of our contributors, no matter how big or small the contributio
 - **[Shannon Deminick (@Shazwazza)](http://github.com/Shazwazza)**
 - **[Jess Pomfret (@jpomfret)](https://github.com/jpomfret)**
 - **[Giuseppe Campanelli (@themilanfan)](https://github.com/themilanfan)**
+- **[Christoph Bergmeister (@bergmeister)](https://github.com/bergmeister)**
 
 ----------
 

--- a/build/pipelines/templates/run-staticAnalysis.yaml
+++ b/build/pipelines/templates/run-staticAnalysis.yaml
@@ -4,12 +4,12 @@
 #
 
 steps:
-  - powershell: |
-      Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -AllowClobber -SkipPublisherCheck -Force -Verbose
+  - pwsh: |
+      Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Verbose
     displayName: 'Install PSScriptAnalyzer'
 
-  - powershell: |
-       $results = Invoke-ScriptAnalyzer -Path ./ –Recurse
+  - pwsh: |
+       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { Get-Error }
        $results | ForEach-Object { Write-Host "##vso[task.logissue type=$($_.Severity);sourcepath=$($_.ScriptPath);linenumber=$($_.Line);columnnumber=$($_.Column);]$($_.Message)" }
 
        $null = New-Item -Path ..\ -Name ScriptAnalyzer -ItemType Directory -Force

--- a/build/pipelines/templates/run-staticAnalysis.yaml
+++ b/build/pipelines/templates/run-staticAnalysis.yaml
@@ -9,7 +9,7 @@ steps:
     displayName: 'Install PSScriptAnalyzer'
 
   - pwsh: |
-       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { Get-Error }
+       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { Get-Error; throw }
        $results | ForEach-Object { Write-Host "##vso[task.logissue type=$($_.Severity);sourcepath=$($_.ScriptPath);linenumber=$($_.Line);columnnumber=$($_.Column);]$($_.Message)" }
 
        $null = New-Item -Path ..\ -Name ScriptAnalyzer -ItemType Directory -Force

--- a/build/pipelines/templates/run-staticAnalysis.yaml
+++ b/build/pipelines/templates/run-staticAnalysis.yaml
@@ -9,7 +9,7 @@ steps:
     displayName: 'Install PSScriptAnalyzer'
 
   - powershell: |
-       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { $StackTrace; throw }
+       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { $_.Exception.StackTrace; throw }
        $results | ForEach-Object { Write-Host "##vso[task.logissue type=$($_.Severity);sourcepath=$($_.ScriptPath);linenumber=$($_.Line);columnnumber=$($_.Column);]$($_.Message)" }
 
        $null = New-Item -Path ..\ -Name ScriptAnalyzer -ItemType Directory -Force

--- a/build/pipelines/templates/run-staticAnalysis.yaml
+++ b/build/pipelines/templates/run-staticAnalysis.yaml
@@ -5,7 +5,7 @@
 
 steps:
   - powershell: |
-      Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -AllowClobber -SkipPublisherCheck -Force -Verbose
+      Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Force -Verbose
     displayName: 'Install PSScriptAnalyzer'
 
   - powershell: |

--- a/build/pipelines/templates/run-staticAnalysis.yaml
+++ b/build/pipelines/templates/run-staticAnalysis.yaml
@@ -4,12 +4,12 @@
 #
 
 steps:
-  - pwsh: |
+  - powershell: |
       Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Verbose
     displayName: 'Install PSScriptAnalyzer'
 
-  - pwsh: |
-       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { Get-Error; throw }
+  - powershell: |
+       $results = try { Invoke-ScriptAnalyzer -Path ./ –Recurse -ErrorAction Stop } catch { $StackTrace; throw }
        $results | ForEach-Object { Write-Host "##vso[task.logissue type=$($_.Severity);sourcepath=$($_.ScriptPath);linenumber=$($_.Line);columnnumber=$($_.Column);]$($_.Message)" }
 
        $null = New-Item -Path ..\ -Name ScriptAnalyzer -ItemType Directory -Force

--- a/build/pipelines/templates/run-staticAnalysis.yaml
+++ b/build/pipelines/templates/run-staticAnalysis.yaml
@@ -5,7 +5,7 @@
 
 steps:
   - powershell: |
-      Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Verbose
+      Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -AllowClobber -SkipPublisherCheck -Force -Verbose
     displayName: 'Install PSScriptAnalyzer'
 
   - powershell: |


### PR DESCRIPTION
## Description

PR https://github.com/microsoft/PowerShellForGitHub/pull/221 reported that this repo causes PSScriptAnalyzer to sporadically throw an error.
In order to report the full error needed for analysis, report the full stack trace. In order to make this easier, I make the build run on PowerShell 7 instead, which has the built-in `Get-Error` cmdlet, which simplifies the reporting.

#### Checklist

- [ ] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] Comment-based help added/updated, including examples.
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis)
is reporting back clean.
- [ ] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).
- [ ] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).
- [ ] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).
- [x] If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)
