### PR TITLE
Fix usage of Resolve-RepositoryElements -DisableValidation

### DIFF
--- a/GitHubContents.ps1
+++ b/GitHubContents.ps1
@@ -138,7 +138,7 @@
 
     Write-InvocationLog
 
-    $elements = Resolve-RepositoryElements -DisableValidation
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -925,8 +925,8 @@ function Resolve-RepositoryElements
     }
     else
     {
-        $elements.ownerName = Resolve-ParameterWithDefaultConfigurationValue -BoundParameters $BoundParameters -Name OwnerName -ConfigValueName DefaultOwnerName -NonEmptyStringRequired:$validate
-        $elements.repositoryName = Resolve-ParameterWithDefaultConfigurationValue -BoundParameters $BoundParameters -Name RepositoryName -ConfigValueName DefaultRepositoryName -NonEmptyStringRequired:$validate
+        $elements.ownerName = Resolve-ParameterWithDefaultConfigurationValue -Name OwnerName -ConfigValueName DefaultOwnerName -NonEmptyStringRequired:$validate
+        $elements.repositoryName = Resolve-ParameterWithDefaultConfigurationValue -Name RepositoryName -ConfigValueName DefaultRepositoryName -NonEmptyStringRequired:$validate
     }
 
     return ([PSCustomObject] $elements)

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -925,8 +925,8 @@ function Resolve-RepositoryElements
     }
     else
     {
-        $elements.ownerName = Resolve-ParameterWithDefaultConfigurationValue -Name OwnerName -ConfigValueName DefaultOwnerName -NonEmptyStringRequired:$validate
-        $elements.repositoryName = Resolve-ParameterWithDefaultConfigurationValue -Name RepositoryName -ConfigValueName DefaultRepositoryName -NonEmptyStringRequired:$validate
+        $elements.ownerName = Resolve-ParameterWithDefaultConfigurationValue -BoundParameters $BoundParameters -Name OwnerName -ConfigValueName DefaultOwnerName -NonEmptyStringRequired:$validate
+        $elements.repositoryName = Resolve-ParameterWithDefaultConfigurationValue -BoundParameters $BoundParameters -Name RepositoryName -ConfigValueName DefaultRepositoryName -NonEmptyStringRequired:$validate
     }
 
     return ([PSCustomObject] $elements)

--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -219,6 +219,9 @@ filter Get-GitHubIssue
 
     Write-InvocationLog
 
+    # Intentionally disabling validation here because parameter sets exist that do not require
+    # an OwnerName and RepositoryName.  Therefore, we will do futher parameter validation further
+    # into the function.
     $elements = Resolve-RepositoryElements -DisableValidation
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
@@ -226,6 +229,7 @@ filter Get-GitHubIssue
     $telemetryProperties = @{
         'OwnerName' = (Get-PiiSafeString -PlainText $OwnerName)
         'RepositoryName' = (Get-PiiSafeString -PlainText $RepositoryName)
+        'OrganizationName' = (Get-PiiSafeString -PlainText $OrganizationName)
         'ProvidedIssue' = $PSBoundParameters.ContainsKey('Issue')
     }
 

--- a/GitHubMiscellaneous.ps1
+++ b/GitHubMiscellaneous.ps1
@@ -312,24 +312,34 @@ filter Get-GitHubLicense
 
     $telemetryProperties = @{}
 
+    # Intentionally disabling validation because parameter sets exist that both require
+    # OwnerName/RepositoryName (to get that repo's License) as well as don't (to get
+    # all known Licenses).  We'll do additional parameter validation within the function.
+    $elements = Resolve-RepositoryElements -DisableValidation
+    $OwnerName = $elements.ownerName
+    $RepositoryName = $elements.repositoryName
+
     $uriFragment = 'licenses'
     $description = 'Getting all licenses'
+
     if ($PSBoundParameters.ContainsKey('Key'))
     {
         $telemetryProperties['Key'] = $Name
         $uriFragment = "licenses/$Key"
         $description = "Getting the $Key license"
     }
-    else
+    elseif ((-not [String]::IsNullOrEmpty($OwnerName)) -and (-not [String]::IsNullOrEmpty($RepositoryName)))
     {
-        $elements = Resolve-RepositoryElements
-        $OwnerName = $elements.ownerName
-        $RepositoryName = $elements.repositoryName
-
         $telemetryProperties['OwnerName'] = Get-PiiSafeString -PlainText $OwnerName
         $telemetryProperties['RepositoryName'] = Get-PiiSafeString -PlainText $RepositoryName
         $uriFragment = "repos/$OwnerName/$RepositoryName/license"
         $description = "Getting the license for $RepositoryName"
+    }
+    elseif ([String]::IsNullOrEmpty($OwnerName) -xor [String]::IsNullOrEmpty($RepositoryName))
+    {
+        $message = 'When specifying OwnerName and/or RepositorName, BOTH must be specified.'
+        Write-Log -Message $message -Level Error
+        throw $message
     }
 
     $params = @{
@@ -537,26 +547,36 @@ filter Get-GitHubCodeOfConduct
 
     Write-InvocationLog
 
+    # Intentionally disabling validation because parameter sets exist that both require
+    # OwnerName/RepositoryName (to get that repo's Code of Conduct) as well as don't (to get
+    # all known Codes of Conduct).  We'll do additional parameter validation within the function.
+    $elements = Resolve-RepositoryElements -DisableValidation
+    $OwnerName = $elements.ownerName
+    $RepositoryName = $elements.repositoryName
+
     $telemetryProperties = @{}
 
     $uriFragment = 'codes_of_conduct'
     $description = 'Getting all Codes of Conduct'
+
     if ($PSBoundParameters.ContainsKey('Key'))
     {
         $telemetryProperties['Key'] = $Name
         $uriFragment = "codes_of_conduct/$Key"
         $description = "Getting the $Key Code of Conduct"
     }
-    else
+    elseif ((-not [String]::IsNullOrEmpty($OwnerName)) -and (-not [String]::IsNullOrEmpty($RepositoryName)))
     {
-        $elements = Resolve-RepositoryElements
-        $OwnerName = $elements.ownerName
-        $RepositoryName = $elements.repositoryName
-
         $telemetryProperties['OwnerName'] = Get-PiiSafeString -PlainText $OwnerName
         $telemetryProperties['RepositoryName'] = Get-PiiSafeString -PlainText $RepositoryName
         $uriFragment = "repos/$OwnerName/$RepositoryName/community/code_of_conduct"
         $description = "Getting the Code of Conduct for $RepositoryName"
+    }
+    elseif ([String]::IsNullOrEmpty($OwnerName) -xor [String]::IsNullOrEmpty($RepositoryName))
+    {
+        $message = 'When specifying OwnerName and/or RepositorName, BOTH must be specified.'
+        Write-Log -Message $message -Level Error
+        throw $message
     }
 
     $params = @{

--- a/GitHubMiscellaneous.ps1
+++ b/GitHubMiscellaneous.ps1
@@ -310,10 +310,6 @@ filter Get-GitHubLicense
 
     Write-InvocationLog
 
-    $elements = Resolve-RepositoryElements -DisableValidation
-    $OwnerName = $elements.ownerName
-    $RepositoryName = $elements.repositoryName
-
     $telemetryProperties = @{}
 
     $uriFragment = 'licenses'
@@ -324,8 +320,12 @@ filter Get-GitHubLicense
         $uriFragment = "licenses/$Key"
         $description = "Getting the $Key license"
     }
-    elseif ((-not [String]::IsNullOrEmpty($OwnerName)) -and (-not [String]::IsNullOrEmpty($RepositoryName)))
+    else
     {
+        $elements = Resolve-RepositoryElements
+        $OwnerName = $elements.ownerName
+        $RepositoryName = $elements.repositoryName
+
         $telemetryProperties['OwnerName'] = Get-PiiSafeString -PlainText $OwnerName
         $telemetryProperties['RepositoryName'] = Get-PiiSafeString -PlainText $RepositoryName
         $uriFragment = "repos/$OwnerName/$RepositoryName/license"
@@ -537,10 +537,6 @@ filter Get-GitHubCodeOfConduct
 
     Write-InvocationLog
 
-    $elements = Resolve-RepositoryElements -DisableValidation
-    $OwnerName = $elements.ownerName
-    $RepositoryName = $elements.repositoryName
-
     $telemetryProperties = @{}
 
     $uriFragment = 'codes_of_conduct'
@@ -551,8 +547,12 @@ filter Get-GitHubCodeOfConduct
         $uriFragment = "codes_of_conduct/$Key"
         $description = "Getting the $Key Code of Conduct"
     }
-    elseif ((-not [String]::IsNullOrEmpty($OwnerName)) -and (-not [String]::IsNullOrEmpty($RepositoryName)))
+    else
     {
+        $elements = Resolve-RepositoryElements
+        $OwnerName = $elements.ownerName
+        $RepositoryName = $elements.repositoryName
+
         $telemetryProperties['OwnerName'] = Get-PiiSafeString -PlainText $OwnerName
         $telemetryProperties['RepositoryName'] = Get-PiiSafeString -PlainText $RepositoryName
         $uriFragment = "repos/$OwnerName/$RepositoryName/community/code_of_conduct"

--- a/GitHubReleases.ps1
+++ b/GitHubReleases.ps1
@@ -176,7 +176,7 @@ filter Get-GitHubRelease
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 

--- a/GitHubReleases.ps1
+++ b/GitHubReleases.ps1
@@ -176,7 +176,7 @@ filter Get-GitHubRelease
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters -DisableValidation
+    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -548,6 +548,10 @@ filter Get-GitHubRepository
 
     Write-InvocationLog -Invocation $MyInvocation
 
+    # We are explicitly disabling validation here because a valid parameter set for this function
+    # allows the OwnerName to be passed in, but not the RepositoryName.  That would allow the caller
+    # to get all of the repositories owned by a specific username.  Therefore, we don't want to fail
+    # if both have not been supplied...we'll do the extra validation within the function.
     $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters -DisableValidation
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -306,6 +306,7 @@ filter Remove-GitHubRepository
         DefaultParameterSetName='Elements',
         ConfirmImpact="High")]
     [Alias('Delete-GitHubRepository')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -1135,6 +1136,7 @@ filter Get-GitHubRepositoryTopic
         DefaultParameterSetName='Elements')]
     [OutputType({$script:GitHubRepositoryTopicTypeName})]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -1438,6 +1440,7 @@ filter Get-GitHubRepositoryContributor
     [OutputType({$script:GitHubUserTypeName})]
     [OutputType({$script:GitHubRepositoryContributorStatisticsTypeName})]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -1581,8 +1584,9 @@ filter Get-GitHubRepositoryCollaborator
     [CmdletBinding(
         SupportsShouldProcess,
         DefaultParameterSetName='Elements')]
-        [OutputType({$script:GitHubUserTypeName})]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [OutputType({$script:GitHubUserTypeName})]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -1696,6 +1700,7 @@ filter Get-GitHubRepositoryLanguage
         DefaultParameterSetName='Elements')]
     [OutputType({$script:GitHubRepositoryLanguageTypeName})]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -1802,6 +1807,7 @@ filter Get-GitHubRepositoryTag
         DefaultParameterSetName='Elements')]
     [OutputType({$script:GitHubRepositoryTagTypeName})]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,
@@ -1913,6 +1919,7 @@ filter Move-GitHubRepositoryOwnership
     [OutputType({$script:GitHubRepositoryTypeName})]
     [Alias('Transfer-GitHubRepositoryOwnership')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="Methods called within here make use of PSShouldProcess, and the switch is passed on to them inherently.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="One or more parameters (like NoStatus) are only referenced by helper methods which get access to it from the stack via Get-Variable -Scope 1.")]
     param(
         [Parameter(ParameterSetName='Elements')]
         [string] $OwnerName,

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -329,7 +329,7 @@ filter Remove-GitHubRepository
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -552,7 +552,7 @@ filter Get-GitHubRepository
     # allows the OwnerName to be passed in, but not the RepositoryName.  That would allow the caller
     # to get all of the repositories owned by a specific username.  Therefore, we don't want to fail
     # if both have not been supplied...we'll do the extra validation within the function.
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters -DisableValidation
+    $elements = Resolve-RepositoryElements -DisableValidation
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1016,7 +1016,7 @@ filter Update-GitHubRepository
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1156,7 +1156,7 @@ filter Get-GitHubRepositoryTopic
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1320,7 +1320,7 @@ function Set-GitHubRepositoryTopic
     {
         Write-InvocationLog -Invocation $MyInvocation
 
-        $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+        $elements = Resolve-RepositoryElements
         $OwnerName = $elements.ownerName
         $RepositoryName = $elements.repositoryName
 
@@ -1463,7 +1463,7 @@ filter Get-GitHubRepositoryContributor
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1607,7 +1607,7 @@ filter Get-GitHubRepositoryCollaborator
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1717,7 +1717,7 @@ filter Get-GitHubRepositoryLanguage
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1823,7 +1823,7 @@ filter Get-GitHubRepositoryTag
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -1940,7 +1940,7 @@ filter Move-GitHubRepositoryOwnership
 
     Write-InvocationLog -Invocation $MyInvocation
 
-    $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 

--- a/GitHubRepositoryForks.ps1
+++ b/GitHubRepositoryForks.ps1
@@ -91,7 +91,7 @@ filter Get-GitHubRepositoryFork
 
     Write-InvocationLog
 
-    $elements = Resolve-RepositoryElements -DisableValidation
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 
@@ -211,7 +211,7 @@ filter New-GitHubRepositoryFork
 
     Write-InvocationLog
 
-    $elements = Resolve-RepositoryElements -DisableValidation
+    $elements = Resolve-RepositoryElements
     $OwnerName = $elements.ownerName
     $RepositoryName = $elements.repositoryName
 

--- a/Tests/GitHubMiscellaneous.tests.ps1
+++ b/Tests/GitHubMiscellaneous.tests.ps1
@@ -99,6 +99,16 @@ Describe 'Get-GitHubLicense' {
         }
     }
 
+    Context 'Will fail if not provided both OwnerName and RepositoryName' {
+        It 'Should fail if only OwnerName is specified' {
+            { Get-GitHubLicense -OwnerName 'PowerShell' } | Should -Throw
+        }
+
+        It 'Should fail if only RepositoryName is specified' {
+            { Get-GitHubLicense -RepositoryName 'PowerShell' } | Should -Throw
+        }
+    }
+
     Context 'Can get the license for a repo with the repo on the pipeline' {
         BeforeAll {
             $result = Get-GitHubRepository -OwnerName 'PowerShell' -RepositoryName 'PowerShell' | Get-GitHubLicense
@@ -210,6 +220,16 @@ Describe 'Get-GitHubCodeOfConduct' {
         It 'Has the expected type and additional properties' {
             $result.PSObject.TypeNames[0] | Should -Be 'GitHub.CodeOfConduct'
             $result.CodeOfConductKey | Should -Be $result.key
+        }
+    }
+
+    Context 'Will fail if not provided both OwnerName and RepositoryName' {
+        It 'Should fail if only OwnerName is specified' {
+            { Get-GitHubCodeOfConduct -OwnerName 'PowerShell' } | Should -Throw
+        }
+
+        It 'Should fail if only RepositoryName is specified' {
+            { Get-GitHubCodeOfConduct -RepositoryName 'PowerShell' } | Should -Throw
         }
     }
 


### PR DESCRIPTION
#### Description

There are only four legitimate instances in the module as of today where we should be disabling the validation that Resolve-RepositoryElements provides.  All other instances were likely introduced due to mistaken copy/paste issues.

The only reason we'd want to disable the validation is if there are multiple parametersets that need to be considered for the function, where at least one _would_ require `OwnerName`/`RepositoryName` while at least one other one _would not_.

This would have meant that we would have attempted to call those GitHub endpoints with incomplete path information which would have most likely resulted in an error that we could have caught sooner without needing to invoke a web request.

I've fixed up all of these incorrect instances, and added a comment to the two remaining ones to remind others later on why that switch is being used, and help prevent incorrect usage in the future.

I've also cleaned up unnecessary passing of `BoundParameters` since it already does the correct thing by default.

#### Issues Fixed
None

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [ ] ~~New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).~~
- [ ] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [ ] ~~Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure thatall pipeline input variations have been covered.~~
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
