### PR TITLE
Fix double-space added after 'Description' throughout module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+    "editor.rulers": [
+        100
+    ],
     "[powershell]": {
         "files.trimTrailingWhitespace": true
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,8 @@ Here are some general guidelines
   reviewing/maintaining code.  There are of course exceptions, but this is generally an enforced
   preference.  The [Visual Studio Productivity Power Tools](https://visualstudiogallery.msdn.microsoft.com/34ebc6a2-2777-421d-8914-e29c1dfa7f5d)
   extension has a "Column Guides" feature that makes it easy to add a Guideline in column 100
-  to make it really obvious when coding.
+  to make it really obvious when coding.  If you use VS Code, this module's `.vscode/settings.json`
+  configures that for you automatically.
 
 ----------
 

--- a/GitHubAssignees.ps1
+++ b/GitHubAssignees.ps1
@@ -100,7 +100,7 @@ filter Get-GitHubAssignee
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/assignees"
-        'Description' =  "Getting assignee list for $RepositoryName"
+        'Description' = "Getting assignee list for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -228,7 +228,7 @@ filter Test-GitHubAssignee
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/assignees/$Assignee"
         'Method' = 'Get'
-        'Description' =  "Checking permission for $Assignee for $RepositoryName"
+        'Description' = "Checking permission for $Assignee for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -411,7 +411,7 @@ function New-GitHubAssignee
             'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/assignees"
             'Body' = (ConvertTo-Json -InputObject $hashBody)
             'Method' = 'Post'
-            'Description' =  "Add assignees to issue $Issue for $RepositoryName"
+            'Description' = "Add assignees to issue $Issue for $RepositoryName"
             'AccessToken' = $AccessToken
             'AcceptHeader' = $script:symmetraAcceptHeader
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -603,7 +603,7 @@ function Remove-GitHubAssignee
                 'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/assignees"
                 'Body' = (ConvertTo-Json -InputObject $hashBody)
                 'Method' = 'Delete'
-                'Description' =  "Removing assignees from issue $Issue for $RepositoryName"
+                'Description' = "Removing assignees from issue $Issue for $RepositoryName"
                 'AccessToken' = $AccessToken
                 'AcceptHeader' = $script:symmetraAcceptHeader
                 'TelemetryEventName' = $MyInvocation.MyCommand.Name

--- a/GitHubBranches.ps1
+++ b/GitHubBranches.ps1
@@ -144,7 +144,7 @@ filter Get-GitHubRepositoryBranch
 
     $params = @{
         'UriFragment' = $uriFragment + '?' + ($getParams -join '&')
-        'Description' =  "Getting branches for $RepositoryName"
+        'Description' = "Getting branches for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubIssueComments.ps1
+++ b/GitHubIssueComments.ps1
@@ -413,7 +413,7 @@ filter New-GitHubIssueComment
         'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/comments"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Post'
-        'Description' =  "Creating comment under issue $Issue for $RepositoryName"
+        'Description' = "Creating comment under issue $Issue for $RepositoryName"
         'AccessToken' = $AccessToken
         'AcceptHeader' = (Get-MediaAcceptHeader -MediaType $MediaType -AsJson -AcceptHeader $squirrelGirlAcceptHeader)
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -556,7 +556,7 @@ filter Set-GitHubIssueComment
         'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/comments/$Comment"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Patch'
-        'Description' =  "Update comment $Comment for $RepositoryName"
+        'Description' = "Update comment $Comment for $RepositoryName"
         'AccessToken' = $AccessToken
         'AcceptHeader' = (Get-MediaAcceptHeader -MediaType $MediaType -AsJson -AcceptHeader $squirrelGirlAcceptHeader)
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -693,7 +693,7 @@ filter Remove-GitHubIssueComment
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/comments/$Comment"
             'Method' = 'Delete'
-            'Description' =  "Removing comment $Comment for $RepositoryName"
+            'Description' = "Removing comment $Comment for $RepositoryName"
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
             'TelemetryProperties' = $telemetryProperties

--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -357,7 +357,7 @@ filter Get-GitHubIssue
 
     $params = @{
         'UriFragment' = $uriFragment + '?' +  ($getParams -join '&')
-        'Description' =  $description
+        'Description' = $description
         'AcceptHeader' = (Get-MediaAcceptHeader -MediaType $MediaType -AsJson -AcceptHeader $symmetraAcceptHeader)
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -484,7 +484,7 @@ filter Get-GitHubIssueTimeline
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/timeline"
-        'Description' =  "Getting timeline for Issue #$Issue in $RepositoryName"
+        'Description' = "Getting timeline for Issue #$Issue in $RepositoryName"
         'AcceptHeader' = $script:mockingbirdAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -643,7 +643,7 @@ filter New-GitHubIssue
         'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Post'
-        'Description' =  "Creating new Issue ""$Title"" on $RepositoryName"
+        'Description' = "Creating new Issue ""$Title"" on $RepositoryName"
         'AcceptHeader' = (Get-MediaAcceptHeader -MediaType $MediaType -AsJson -AcceptHeader $symmetraAcceptHeader)
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -823,7 +823,7 @@ filter Update-GitHubIssue
         'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues/$Issue"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Patch'
-        'Description' =  "Updating Issue #$Issue on $RepositoryName"
+        'Description' = "Updating Issue #$Issue on $RepositoryName"
         'AcceptHeader' = (Get-MediaAcceptHeader -MediaType $MediaType -AsJson -AcceptHeader $symmetraAcceptHeader)
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -956,7 +956,7 @@ filter Lock-GitHubIssue
         'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues/$Issue/lock"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Put'
-        'Description' =  "Locking Issue #$Issue on $RepositoryName"
+        'Description' = "Locking Issue #$Issue on $RepositoryName"
         'AcceptHeader' = $script:sailorVAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -1066,7 +1066,7 @@ filter Unlock-GitHubIssue
     $params = @{
         'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues/$Issue/lock"
         'Method' = 'Delete'
-        'Description' =  "Unlocking Issue #$Issue on $RepositoryName"
+        'Description' = "Unlocking Issue #$Issue on $RepositoryName"
         'AcceptHeader' = $script:sailorVAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name

--- a/GitHubLabels.ps1
+++ b/GitHubLabels.ps1
@@ -182,7 +182,7 @@ filter Get-GitHubLabel
 
     $params = @{
         'UriFragment' = $uriFragment
-        'Description' =  $description
+        'Description' = $description
         'AcceptHeader' = $script:symmetraAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -327,7 +327,7 @@ filter New-GitHubLabel
         'UriFragment' = "repos/$OwnerName/$RepositoryName/labels"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Post'
-        'Description' =  "Creating label $Label in $RepositoryName"
+        'Description' = "Creating label $Label in $RepositoryName"
         'AcceptHeader' = $script:symmetraAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -474,7 +474,7 @@ filter Remove-GitHubLabel
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/labels/$Label"
             'Method' = 'Delete'
-            'Description' =  "Deleting label $Label from $RepositoryName"
+            'Description' = "Deleting label $Label from $RepositoryName"
             'AcceptHeader' = $script:symmetraAcceptHeader
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -626,7 +626,7 @@ filter Update-GitHubLabel
         'UriFragment' = "repos/$OwnerName/$RepositoryName/labels/$Label"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Patch'
-        'Description' =  "Updating label $Label"
+        'Description' = "Updating label $Label"
         'AcceptHeader' = $script:symmetraAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -928,7 +928,7 @@ function Add-GitHubIssueLabel
             'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/labels"
             'Body' = (ConvertTo-Json -InputObject $hashBody)
             'Method' = 'Post'
-            'Description' =  "Adding labels to issue $Issue in $RepositoryName"
+            'Description' = "Adding labels to issue $Issue in $RepositoryName"
             'AcceptHeader' = $script:symmetraAcceptHeader
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -1117,7 +1117,7 @@ function Set-GitHubIssueLabel
             'UriFragment' = "repos/$OwnerName/$RepositoryName/issues/$Issue/labels"
             'Body' = (ConvertTo-Json -InputObject $hashBody)
             'Method' = 'Put'
-            'Description' =  "Replacing labels to issue $Issue in $RepositoryName"
+            'Description' = "Replacing labels to issue $Issue in $RepositoryName"
             'AcceptHeader' = $script:symmetraAcceptHeader
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -1275,7 +1275,7 @@ filter Remove-GitHubIssueLabel
         $params = @{
             'UriFragment' = "/repos/$OwnerName/$RepositoryName/issues/$Issue/labels/$Label"
             'Method' = 'Delete'
-            'Description' =  $description
+            'Description' = $description
             'AcceptHeader' = $script:symmetraAcceptHeader
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name

--- a/GitHubMilestones.ps1
+++ b/GitHubMilestones.ps1
@@ -380,7 +380,7 @@ filter New-GitHubMilestone
         'UriFragment' = "repos/$OwnerName/$RepositoryName/milestones"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Post'
-        'Description' =  "Creating milestone for $RepositoryName"
+        'Description' = "Creating milestone for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -571,7 +571,7 @@ filter Set-GitHubMilestone
         'UriFragment' = "repos/$OwnerName/$RepositoryName/milestones/$Milestone"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Patch'
-        'Description' =  "Setting milestone $Milestone for $RepositoryName"
+        'Description' = "Setting milestone $Milestone for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -714,7 +714,7 @@ filter Remove-GitHubMilestone
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName/milestones/$Milestone"
             'Method' = 'Delete'
-            'Description' =  "Removing milestone $Milestone for $RepositoryName"
+            'Description' = "Removing milestone $Milestone for $RepositoryName"
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
             'TelemetryProperties' = $telemetryProperties

--- a/GitHubMiscellaneous.ps1
+++ b/GitHubMiscellaneous.ps1
@@ -77,7 +77,7 @@ function Get-GitHubRateLimit
     $params = @{
         'UriFragment' = 'rate_limit'
         'Method' = 'Get'
-        'Description' =  "Getting your API rate limit"
+        'Description' = "Getting your API rate limit"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
@@ -186,7 +186,7 @@ function ConvertFrom-GitHubMarkdown
             'UriFragment' = 'markdown'
             'Body' = (ConvertTo-Json -InputObject $hashBody)
             'Method' = 'Post'
-            'Description' =  "Converting Markdown to HTML"
+            'Description' = "Converting Markdown to HTML"
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
             'TelemetryProperties' = $telemetryProperties
@@ -345,7 +345,7 @@ filter Get-GitHubLicense
     $params = @{
         'UriFragment' = $uriFragment
         'Method' = 'Get'
-        'Description' =  $description
+        'Description' = $description
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -425,7 +425,7 @@ function Get-GitHubEmoji
     $params = @{
         'UriFragment' = 'emojis'
         'Method' = 'Get'
-        'Description' =  "Getting all GitHub emojis"
+        'Description' = "Getting all GitHub emojis"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)
@@ -583,7 +583,7 @@ filter Get-GitHubCodeOfConduct
         'UriFragment' = $uriFragment
         'Method' = 'Get'
         'AcceptHeader' = $script:scarletWitchAcceptHeader
-        'Description' =  $description
+        'Description' = $description
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -680,7 +680,7 @@ filter Get-GitHubGitIgnore
     $params = @{
         'UriFragment' = $uriFragment
         'Method' = 'Get'
-        'Description' =  $description
+        'Description' = $description
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubOrganizations.ps1
+++ b/GitHubOrganizations.ps1
@@ -67,7 +67,7 @@ filter Get-GitHubOrganizationMember
 
     $params = @{
         'UriFragment' = "orgs/$OrganizationName/members"
-        'Description' =  "Getting members for $OrganizationName"
+        'Description' = "Getting members for $OrganizationName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -144,7 +144,7 @@ filter Test-GitHubOrganizationMember
 
     $params = @{
         'UriFragment' = "orgs/$OrganizationName/members/$UserName"
-        'Description' =  "Checking if $UserName is a member of $OrganizationName"
+        'Description' = "Checking if $UserName is a member of $OrganizationName"
         'Method' = 'Get'
         'ExtendedResult' = $true
         'AccessToken' = $AccessToken

--- a/GitHubPullRequests.ps1
+++ b/GitHubPullRequests.ps1
@@ -180,7 +180,7 @@ filter Get-GitHubPullRequest
 
     $params = @{
         'UriFragment' = $uriFragment + '?' +  ($getParams -join '&')
-        'Description' =  $description
+        'Description' = $description
         'AcceptHeader' = $script:symmetraAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name

--- a/GitHubReleases.ps1
+++ b/GitHubReleases.ps1
@@ -214,7 +214,7 @@ filter Get-GitHubRelease
 
     $params = @{
         'UriFragment' = $uriFragment
-        'Description' =  $description
+        'Description' = $description
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -349,7 +349,7 @@ filter Remove-GitHubRepository
         $params = @{
             'UriFragment' = "repos/$OwnerName/$RepositoryName"
             'Method' = 'Delete'
-            'Description' =  "Deleting $RepositoryName"
+            'Description' = "Deleting $RepositoryName"
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
             'TelemetryProperties' = $telemetryProperties
@@ -692,7 +692,7 @@ filter Get-GitHubRepository
 
     $params = @{
         'UriFragment' = $uriFragment + '?' +  ($getParams -join '&')
-        'Description' =  $description
+        'Description' = $description
         'AcceptHeader' = "$script:nebulaAcceptHeader,$script:baptisteAcceptHeader,$script:mercyAcceptHeader"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -1063,7 +1063,7 @@ filter Update-GitHubRepository
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Patch'
         'AcceptHeader' = $script:baptisteAcceptHeader
-        'Description' =  "Updating $RepositoryName"
+        'Description' = "Updating $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -1170,7 +1170,7 @@ filter Get-GitHubRepositoryTopic
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/topics"
         'Method' = 'Get'
-        'Description' =  "Getting topics for $RepositoryName"
+        'Description' = "Getting topics for $RepositoryName"
         'AcceptHeader' = $script:mercyAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -1349,7 +1349,7 @@ function Set-GitHubRepositoryTopic
             'UriFragment' = "repos/$OwnerName/$RepositoryName/topics"
             'Body' = (ConvertTo-Json -InputObject $hashBody)
             'Method' = 'Put'
-            'Description' =  $description
+            'Description' = $description
             'AcceptHeader' = $script:mercyAcceptHeader
             'AccessToken' = $AccessToken
             'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -1485,7 +1485,7 @@ filter Get-GitHubRepositoryContributor
 
     $params = @{
         'UriFragment' = $uriFragment + '?' + ($getParams -join '&')
-        'Description' =  "Getting contributors for $RepositoryName"
+        'Description' = "Getting contributors for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -1626,7 +1626,7 @@ filter Get-GitHubRepositoryCollaborator
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/collaborators?" + ($getParams -join '&')
-        'Description' =  "Getting collaborators for $RepositoryName"
+        'Description' = "Getting collaborators for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -1733,7 +1733,7 @@ filter Get-GitHubRepositoryLanguage
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/languages"
-        'Description' =  "Getting languages for $RepositoryName"
+        'Description' = "Getting languages for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -1840,7 +1840,7 @@ filter Get-GitHubRepositoryTag
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/tags"
-        'Description' =  "Getting tags for $RepositoryName"
+        'Description' = "Getting tags for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -1966,7 +1966,7 @@ filter Move-GitHubRepositoryOwnership
         'UriFragment' = "repos/$OwnerName/$RepositoryName/transfer"
         'Body' = (ConvertTo-Json -InputObject $hashBody)
         'Method' = 'Post'
-        'Description' =  "Transferring ownership of $RepositoryName to $NewOwnerName"
+        'Description' = "Transferring ownership of $RepositoryName to $NewOwnerName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubRepositoryForks.ps1
+++ b/GitHubRepositoryForks.ps1
@@ -107,7 +107,7 @@ filter Get-GitHubRepositoryFork
 
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/forks`?" +  ($getParams -join '&')
-        'Description' =  "Getting all forks of $RepositoryName"
+        'Description' = "Getting all forks of $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -231,7 +231,7 @@ filter New-GitHubRepositoryFork
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/forks`?" +  ($getParams -join '&')
         'Method' = 'Post'
-        'Description' =  "Creating fork of $RepositoryName"
+        'Description' = "Creating fork of $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubRepositoryTraffic.ps1
+++ b/GitHubRepositoryTraffic.ps1
@@ -106,7 +106,7 @@ filter Get-GitHubReferrerTraffic
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/popular/referrers"
         'Method' = 'Get'
-        'Description' =  "Getting referrers for $RepositoryName"
+        'Description' = "Getting referrers for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -220,7 +220,7 @@ filter Get-GitHubPathTraffic
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/popular/paths"
         'Method' = 'Get'
-        'Description' =  "Getting popular contents for $RepositoryName"
+        'Description' = "Getting popular contents for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -344,7 +344,7 @@ filter Get-GitHubViewTraffic
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/views`?per=$($Per.ToLower())"
         'Method' = 'Get'
-        'Description' =  "Getting views for $RepositoryName"
+        'Description' = "Getting views for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -468,7 +468,7 @@ filter Get-GitHubCloneTraffic
     $params = @{
         'UriFragment' = "repos/$OwnerName/$RepositoryName/traffic/clones`?per=$($Per.ToLower())"
         'Method' = 'Get'
-        'Description' =  "Getting number of clones for $RepositoryName"
+        'Description' = "Getting number of clones for $RepositoryName"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubTeams.ps1
+++ b/GitHubTeams.ps1
@@ -146,7 +146,7 @@ filter Get-GitHubTeam
     $params = @{
         'UriFragment' = $uriFragment
         'AcceptHeader' = $script:hellcatAcceptHeader
-        'Description' =  $description
+        'Description' = $description
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties
@@ -266,7 +266,7 @@ filter Get-GitHubTeamMember
 
     $params = @{
         'UriFragment' = "teams/$TeamId/members"
-        'Description' =  "Getting members of team $TeamId"
+        'Description' = "Getting members of team $TeamId"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'TelemetryProperties' = $telemetryProperties

--- a/GitHubUsers.ps1
+++ b/GitHubUsers.ps1
@@ -275,7 +275,7 @@ filter Get-GitHubUserContextualInformation
     $params = @{
         'UriFragment' = "users/$UserName/hovercard`?" + ($getParams -join '&')
         'Method' = 'Get'
-        'Description' =  "Getting hovercard information for $UserName"
+        'Description' = "Getting hovercard information for $UserName"
         'AcceptHeader' = $script:hagarAcceptHeader
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
@@ -390,7 +390,7 @@ function Update-GitHubCurrentUser
         'UriFragment' = 'user'
         'Method' = 'Patch'
         'Body' = (ConvertTo-Json -InputObject $hashBody)
-        'Description' =  "Updating current authenticated user"
+        'Description' = "Updating current authenticated user"
         'AccessToken' = $AccessToken
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
         'NoStatus' = (Resolve-ParameterWithDefaultConfigurationValue -Name NoStatus -ConfigValueName DefaultNoStatus)


### PR DESCRIPTION
#### Description
Somehow two spaces got added after `'Description' =` in a function and then got copy/paste repeated throughout the module.

This fixes that.

It also adds a ruler line at the 100 character mark in VS Code to help developers see when they should start to wrap their code/comments.


#### Issues Fixed
n/a

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [ ] ~~New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).~~
- [ ] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [ ] ~~Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.~~
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
