### PR TITLE
Improve CI speed by changing repo targeted by Forks tests

### DIFF
--- a/Tests/GitHubRepositoryForks.tests.ps1
+++ b/Tests/GitHubRepositoryForks.tests.ps1
@@ -20,7 +20,7 @@ try
     # Define Script-scoped, readonly, hidden variables.
     @{
         upstreamOwnerName = 'octocat'
-        upstreamRepositoryName = 'Hello-World'
+        upstreamRepositoryName = 'git-consortium'
     }.GetEnumerator() | ForEach-Object {
         Set-Variable -Force -Scope Script -Option ReadOnly -Visibility Private -Name $_.Key -Value $_.Value
     }


### PR DESCRIPTION
#### Description
Pull #251 changed the repo targeted by the forks tests from `microsoft/PowerShellForGitHub` to `octocat/Hello-World` in order to prevent the accidental deletion of real forks when running the UT's locally against your own account.

In practice, this almost doubled the execution time of the UT's, because the execution time of the Forks API's took so much longer against a repo with 1400+ forks.

Changing the test over to use a repo that currently only has 39 forks (several orders of magnitude fewer).

#### Issues Fixed
n/a

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [ ] ~~New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).~~
- [ ] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [ ] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~