### PR TITLE
Fix pipeline support and testing for New-GitHubRepositoryFromTemplate

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -364,6 +364,7 @@ filter New-GitHubRepositoryFromTemplate
 
     $elements = Resolve-RepositoryElements -BoundParameters $PSBoundParameters
     $OwnerName = $elements.ownerName
+    $RepositoryName = $elements.repositoryName
 
     $telemetryProperties = @{
         RepositoryName = (Get-PiiSafeString -PlainText $RepositoryName)


### PR DESCRIPTION
#### Description
Added in #221, `New-GitHubRepositoryFromTemplate was not capturing the passed-in value for the RepositoryName if provided via a Uri parameter.

There was a pipeline test in place, however it missed this fact because it was only testing the pipeline input scenario using `-WhatIf`, and the error was only found when calling the actual REST API and GitHub noticed that the `RepositoryName` was missing from the URI.

#### Issues Fixed
n/a

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [x] New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
