### PR TITLE
Fix handling of numerical configuration properties across PS5 and PS7

### DIFF
--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -466,16 +466,18 @@ function Resolve-PropertyValue
     if ($Type -eq 'Boolean') { $typeType = [Boolean] }
     if ($Type -eq 'Int32') { $typeType = [Int32] }
     if ($Type -eq 'Int64') { $typeType = [Int64] }
+    $numberEquivalents = @('Int32', 'Int64', 'long', 'int')
 
     if (Test-PropertyExists -InputObject $InputObject -Name $Name)
     {
-        if ($InputObject.$Name -is $typeType)
+        if (($InputObject.$Name -is $typeType) -or
+            (($Type -in $numberEquivalents) -and ($InputObject.$Name.GetType().Name -in $numberEquivalents)))
         {
             return $InputObject.$Name
         }
         else
         {
-            $message = "The locally cached $Name configuration was not of type $Type.  Reverting to default value."
+            $message = "The locally cached $Name configuration was not of type $Type (it was $($InputObject.$Name.GetType())).  Reverting to default value."
             Write-Log -Message $message -Level Warning
             return $DefaultValue
         }


### PR DESCRIPTION
#### Description
`ConvertFrom-Json` defaults numbers to different types depending on the PowerShell version.

PS5 defaults numbers to `[Int32]` while PS7 defaults numbers to `[Int64]`, but both versions default to `[Int32]` in a `[PSCustomObject]`.

Due to this, if you had a number config value saved, on PS7 it would be ignored and the default value would be used because the expected and actual types wouldn't match.

I've updated `Resolve-PropertyValue` to have equivalence logic for number types to avoid this issue.

#### Issues Fixed
n/a

#### References
n/a

#### Checklist
<!--
    To aid reviewers, please take the time to run through the below checklist
    and make sure your PR has everything updated as required.

    Change to [x] for each task in the task list that you have completed.
    If a task doesn't apply, add a strikethrough by putting "~~" before and after the text.
-->
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [ ] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [ ] ~~Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.~~
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
