### PR TITLE
Attempting to increase reliability of some Pester tests - take 2

### DIFF
--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -147,6 +147,11 @@ function Set-GitHubConfiguration
     .PARAMETER RetryDelaySeconds
         The number of seconds to wait before retrying a command again after receiving a 202 response.
 
+    .PARAMETER StateChangeDelaySeconds
+        The number of seconds to wait before returning the result after executing a command that
+        may result in a state change on the server.  This is intended to only be used during test
+        execution in order to increase reliability.
+
     .PARAMETER SuppressNoTokenWarning
         If an Access Token has not been configured, this module will provide a warning to the user
         informing them of this, once per session.  If it is expected that this module will regularly
@@ -227,6 +232,8 @@ function Set-GitHubConfiguration
         [int] $MultiRequestProgressThreshold,
 
         [int] $RetryDelaySeconds,
+
+        [int] $StateChangeDelaySeconds,
 
         [switch] $SuppressNoTokenWarning,
 
@@ -312,6 +319,7 @@ function Get-GitHubConfiguration
             'LogTimeAsUtc',
             'MultiRequestProgressThreshold',
             'RetryDelaySeconds',
+            'StateChangeDelaySeconds',
             'SuppressNoTokenWarning',
             'SuppressTelemetryReminder',
             'TestConfigSettingsHash',
@@ -659,6 +667,7 @@ function Import-GitHubConfiguration
         'logTimeAsUtc' = $false
         'multiRequestProgressThreshold' = 10
         'retryDelaySeconds' = 30
+        'stateChangeDelaySeconds' = 0
         'suppressNoTokenWarning' = $false
         'suppressTelemetryReminder' = $false
         'webRequestTimeoutSec' = 0

--- a/GitHubCore.ps1
+++ b/GitHubCore.ps1
@@ -321,6 +321,16 @@ function Invoke-GHRestMethod
             }
         }
 
+        # Allow for a delay after a command that may result in a state change in order to
+        #increase the reliability of the UT's which attempt multiple successive state change
+        # on the same object.
+        $stateChangeDelaySeconds = $(Get-GitHubConfiguration -Name 'StateChangeDelaySeconds')
+        $stateChangeMethods = @('Delete', 'Post', 'Patch', 'Put')
+        if (($stateChangeDelaySeconds -gt 0) -and ($Method -in $stateChangeMethods))
+        {
+            Start-Sleep -Seconds $stateChangeDelaySeconds
+        }
+
         if ($ExtendedResult)
         {
             $finalResultEx = @{

--- a/Tests/Common.ps1
+++ b/Tests/Common.ps1
@@ -101,9 +101,10 @@ function Initialize-CommonTestSetup
     Set-GitHubConfiguration -MultiRequestProgressThreshold 0 # Status corrupts the raw CI logs for Linux and Mac, and makes runs take slightly longer.
     Set-GitHubConfiguration -DisableUpdateCheck # The update check is unnecessary during tests.
 
-    # The number of seconds to sleep after performing some operations to ensure that successive
-    # API calls properly reflect previously updated state.
-    $script:defaultSleepSecondsForReliability = 3
+    # We execute so many successive state changing commands on the same object that sometimes
+    # GitHub gets confused.  We'll add an intentional delay to slow down our execution in an effort
+    # to increase the reliability of the tests.
+    Set-GitHubConfiguration -StateChangeDelaySeconds 3
 }
 
 Initialize-CommonTestSetup

--- a/Tests/GitHubAssignees.tests.ps1
+++ b/Tests/GitHubAssignees.tests.ps1
@@ -108,20 +108,12 @@ try
         Context 'Adding and removing an assignee via parameters' {
             $issue = $repo | New-GitHubIssue -Title "Test issue"
 
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             It 'Should have no assignees when created' {
                 $issue.assignee.login | Should -BeNullOrEmpty
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
             $updatedIssue = Add-GitHubAssignee -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $issue.number -Assignee $owner.login
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number
@@ -155,20 +147,12 @@ try
         Context 'Adding an assignee with the repo on the pipeline' {
             $issue = $repo | New-GitHubIssue -Title "Test issue"
 
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             It 'Should have no assignees when created' {
                 $issue.assignee.login | Should -BeNullOrEmpty
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
             $updatedIssue = $repo | Add-GitHubAssignee -Issue $issue.number -Assignee $owner.login
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number
@@ -202,20 +186,12 @@ try
         Context 'Adding an assignee with the issue on the pipeline' {
             $issue = $repo | New-GitHubIssue -Title "Test issue"
 
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             It 'Should have no assignees when created' {
                 $issue.assignee.login | Should -BeNullOrEmpty
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
             $updatedIssue = $issue | Add-GitHubAssignee -Assignee $owner.login
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number
@@ -249,20 +225,12 @@ try
         Context 'Adding an assignee with the assignee user object on the pipeline' {
             $issue = $repo | New-GitHubIssue -Title "Test issue"
 
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             It 'Should have no assignees when created' {
                 $issue.assignee.login | Should -BeNullOrEmpty
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
             $updatedIssue = $owner | Add-GitHubAssignee -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $issue.number
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number

--- a/Tests/GitHubContents.tests.ps1
+++ b/Tests/GitHubContents.tests.ps1
@@ -37,10 +37,6 @@ try
         BeforeAll {
             # AutoInit will create a readme with the GUID of the repo name
             $repo = New-GitHubRepository -RepositoryName ($repoGuid) -AutoInit
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         AfterAll {
@@ -262,12 +258,7 @@ try
     Describe 'GitHubContents/Set-GitHubContent' {
         BeforeAll {
             $repoName = [Guid]::NewGuid().Guid
-
             $repo = New-GitHubRepository -RepositoryName $repoName -AutoInit
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         Context 'When setting new file content' {

--- a/Tests/GitHubIssues.tests.ps1
+++ b/Tests/GitHubIssues.tests.ps1
@@ -161,9 +161,6 @@ try
             for ($i = 0; $i -lt 4; $i++)
             {
                 $newIssues += New-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Title ([Guid]::NewGuid().Guid)
-
-                 # Needed to ensure that there is a unique creation timestamp between issues
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             $newIssues[0] = Set-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[0].number -State Closed
@@ -549,10 +546,6 @@ try
             }
 
             Lock-GitHubIssue -OwnerName $script:OwnerName -RepositoryName $repo.name -Issue $issue.number
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
 
             $timeline = @(Get-GitHubIssueTimeline -OwnerName $script:OwnerName -RepositoryName $repo.name -Issue $issue.number)
             It 'Should have an event now' {

--- a/Tests/GitHubLabels.tests.ps1
+++ b/Tests/GitHubLabels.tests.ps1
@@ -80,11 +80,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             Initialize-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $defaultLabels
         }
 
@@ -209,10 +204,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         AfterAll {
@@ -327,10 +318,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         AfterAll {
@@ -339,11 +326,6 @@ try
 
         Context 'Removing a label with parameters' {
             $label = $repo | New-GitHubLabel -Label 'test' -Color 'CCCCCC'
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             Remove-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Force
 
             It 'Should be gone after being removed by parameter' {
@@ -353,11 +335,6 @@ try
 
         Context 'Removing a label with the repo on the pipeline' {
             $label = $repo | New-GitHubLabel -Label 'test' -Color 'CCCCCC'
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $repo | Remove-GitHubLabel -Label $label.name -Confirm:$false
 
             It 'Should be gone after being removed by parameter' {
@@ -367,11 +344,6 @@ try
 
         Context 'Removing a label with the name on the pipeline' {
             $label = $repo | New-GitHubLabel -Label 'test' -Color 'CCCCCC'
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $label.name | Remove-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Force
 
             It 'Should be gone after being removed by parameter' {
@@ -381,11 +353,6 @@ try
 
         Context 'Removing a label with the label object on the pipeline' {
             $label = $repo | New-GitHubLabel -Label 'test' -Color 'CCCCCC'
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $label | Remove-GitHubLabel -Force
 
             It 'Should be gone after being removed by parameter' {
@@ -398,10 +365,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         AfterAll {
@@ -579,10 +542,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         AfterAll {
@@ -657,11 +616,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $repo | Initialize-GitHubLabel -Label $defaultLabels
         }
 
@@ -890,11 +844,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $repo | Initialize-GitHubLabel -Label $defaultLabels
         }
 
@@ -961,11 +910,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $repo | Initialize-GitHubLabel -Label $defaultLabels
         }
 
@@ -1133,11 +1077,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $repo | Initialize-GitHubLabel -Label $defaultLabels
         }
 
@@ -1287,11 +1226,6 @@ try
         BeforeAll {
             $repositoryName = [Guid]::NewGuid().Guid
             $repo = New-GitHubRepository -RepositoryName $repositoryName
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $repo | Initialize-GitHubLabel -Label $defaultLabels
 
             $milestone = $repo | New-GitHubMilestone -Title 'test milestone'

--- a/Tests/GitHubProjects.tests.ps1
+++ b/Tests/GitHubProjects.tests.ps1
@@ -611,10 +611,6 @@ try
             $project = New-GitHubProject -OwnerName $script:ownerName -RepositoryName $repo.name -ProjectName $defaultRepoProject -Description $defaultRepoProjectDesc
             $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             It 'Project should be removed' {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 {Get-GitHubProject -Project $project.id} | Should -Throw
             }
         }
@@ -623,10 +619,6 @@ try
             $project = $repo | New-GitHubProject -ProjectName $defaultRepoProject -Description $defaultRepoProjectDesc
             $project | Remove-GitHubProject -Force
             It 'Project should be removed' {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 {$project | Get-GitHubProject} | Should -Throw
             }
         }

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -124,11 +124,8 @@ try
                         LicenseTemplate = $testLicenseTemplate
                         IsTemplate = $true
                     }
-                    $repo = New-GitHubRepository @newGitHubRepositoryParms
 
-                    # The CI build has been unreliable with this test.
-                    # Adding a short sleep to ensure successive queries reflect updated state.
-                    Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
+                    $repo = New-GitHubRepository @newGitHubRepositoryParms
                 }
 
                 It 'Should return an object of the correct type' {
@@ -310,10 +307,6 @@ try
             }
 
             $templateRepo = New-GitHubRepository @newGitHubRepositoryParms
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         Context 'When creating a public repository from a template' {
@@ -329,10 +322,6 @@ try
                 }
 
                 $repo = New-GitHubRepositoryFromTemplate @newGitHubRepositoryFromTemplateParms
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             It 'Should have the expected type and addititional properties' {
@@ -373,10 +362,6 @@ try
                 }
 
                 $repo = $templateRepo | New-GitHubRepositoryFromTemplate @newGitHubRepositoryFromTemplateParms
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             It 'Should have the expected type and addititional properties' {
@@ -419,10 +404,6 @@ try
             BeforeAll {
                 $publicRepo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
                 $privateRepo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -Private
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             Context 'When specify the visibility parameter' {
@@ -556,10 +537,6 @@ try
         Context 'When getting a repository for a specified organization' {
             BeforeAll {
                 $repo = New-GitHubRepository -OrganizationName $script:organizationName -RepositoryName ([Guid]::NewGuid().Guid)
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             It "Should have results for the organization" {
@@ -576,11 +553,6 @@ try
             BeforeAll {
                 $repo1 = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
                 $repo2 = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 $repos = Get-GitHubRepository -GetAllPublicRepositories -Since $repo1.id
             }
 
@@ -612,10 +584,6 @@ try
                 }
 
                 $repo = New-GitHubRepository @newGitHubRepositoryParms
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             Context 'When specifiying the Uri parameter' {
@@ -691,21 +659,11 @@ try
 
             It 'Should get no content using -Confirm:$false' {
                 Remove-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -Confirm:$false
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 { Get-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name } | Should -Throw
             }
 
             It 'Should get no content using -Force' {
                 Remove-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -Force
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 { Get-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name } | Should -Throw
             }
         }
@@ -718,55 +676,31 @@ try
                 $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid) -AutoInit
                 $suffixToAddToRepo = "_renamed"
                 $newRepoName = "$($repo.name)$suffixToAddToRepo"
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             It "Should have the expected new repository name - by URI" {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 $renamedRepo = Rename-GitHubRepository -Uri ($repo.RepositoryUrl) -NewName $newRepoName -Force
                 $renamedRepo.name | Should -Be $newRepoName
             }
 
             It "Should have the expected new repository name - by Elements" {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 $renamedRepo = Rename-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -NewName $newRepoName -Confirm:$false
                 $renamedRepo.name | Should -Be $newRepoName
             }
 
             It "Should work via the pipeline" {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 $renamedRepo = $repo | Rename-GitHubRepository -NewName $newRepoName -Confirm:$false
                 $renamedRepo.name | Should -Be $newRepoName
                 $renamedRepo.PSObject.TypeNames[0] | Should -Be 'GitHub.Repository'
             }
 
             It "Should be possible to rename with Set-GitHubRepository too" {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 $renamedRepo = $repo | Set-GitHubRepository -NewName $newRepoName -Confirm:$false
                 $renamedRepo.name | Should -Be $newRepoName
                 $renamedRepo.PSObject.TypeNames[0] | Should -Be 'GitHub.Repository'
             }
 
             AfterEach -Scriptblock {
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 Remove-GitHubRepository -Uri "$($repo.svn_url)$suffixToAddToRepo" -Confirm:$false
             }
         }
@@ -778,10 +712,6 @@ try
             BeforeAll -ScriptBlock {
                 $repoName = ([Guid]::NewGuid().Guid)
                 $repo = New-GitHubRepository -RepositoryName $repoName
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             Context -Name 'When updating a repository with all possible settings' {
@@ -884,10 +814,6 @@ try
                 $repoName = ([Guid]::NewGuid().Guid)
                 $repo = New-GitHubRepository -RepositoryName $repoName -Private
 
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 $updateGithubRepositoryParms = @{
                     OwnerName = $repo.owner.login
                     RepositoryName = $repoName
@@ -944,10 +870,6 @@ try
             It 'Should be removable by the pipeline' {
                 ($repo | Remove-GitHubRepository -Confirm:$false) | Should -BeNullOrEmpty
 
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 { $repo | Get-GitHubRepository } | Should -Throw
             }
         }
@@ -983,11 +905,6 @@ try
 
             It 'Should be removable by the pipeline' {
                 ($repo | Remove-GitHubRepository -Confirm:$false) | Should -BeNullOrEmpty
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
                 { $repo | Get-GitHubRepository } | Should -Throw
             }
         }
@@ -1058,11 +975,6 @@ try
     Describe 'GitHubRepositories\Set-GitHubRepositoryTopic' {
         BeforeAll {
             $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
-
             $topic = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Name $defaultRepoTopic
         }
 
@@ -1342,10 +1254,6 @@ try
     Describe 'GitHubRepositories\Enable-GitHubRepositoryVulnerabilityAlert' {
         BeforeAll {
             $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         Context 'When Enabling GitHub Repository Vulnerability Alerts' {
@@ -1381,10 +1289,6 @@ try
     Describe 'GitHubRepositories\Enable-GitHubRepositorySecurityFix' {
         BeforeAll {
             $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
-
-            # The CI build has been unreliable with this test.
-            # Adding a short sleep to ensure successive queries reflect updated state.
-            Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
         }
 
         Context 'When Enabling GitHub Repository Security Fixes' {

--- a/Tests/GitHubRepositoryForks.tests.ps1
+++ b/Tests/GitHubRepositoryForks.tests.ps1
@@ -29,10 +29,6 @@ try
         Context 'When a new fork is created' {
             BeforeAll {
                 $repo = New-GitHubRepositoryFork -OwnerName $script:upstreamOwnerName -RepositoryName $script:upstreamRepositoryName
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             AfterAll {
@@ -58,10 +54,6 @@ try
             BeforeAll {
                 $upstream = Get-GitHubRepository -OwnerName $script:upstreamOwnerName -RepositoryName $script:upstreamRepositoryName
                 $repo = $upstream | New-GitHubRepositoryFork
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             AfterAll {
@@ -88,10 +80,6 @@ try
         Context 'When a new fork is created' {
             BeforeAll {
                 $repo = New-GitHubRepositoryFork -OwnerName $script:upstreamOwnerName -RepositoryName $script:upstreamRepositoryName -OrganizationName $script:organizationName
-
-                # The CI build has been unreliable with this test.
-                # Adding a short sleep to ensure successive queries reflect updated state.
-                Start-Sleep -Seconds $script:defaultSleepSecondsForReliability
             }
 
             AfterAll {


### PR DESCRIPTION
#### Description
This is re-implementing #265 in a more robust way, thanks to a suggestion from @X-Guardian in #267.

Instead of adding in one-off sleeps throughout the test codebase, there is now a new configuration value (`StateChangeDelaySeconds`) that will allow us to insert a delay before returning the result of _any_ state change request.

This should ideally consistently add reliability throughout the entire test codebase.

#### Issues Fixed
Fixes #264

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] Comment-based help added/updated, including examples.
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [ ] ~~[Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.~~
- [ ] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [ ] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- [ ] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [ ] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~