### PR TITLE
Updates all state-changing commands to be silent by default (with -Passthru)

### DIFF
--- a/GitHubAssignees.ps1
+++ b/GitHubAssignees.ps1
@@ -257,6 +257,11 @@ function Add-GitHubAssignee
         NOTE: Only users with push access can add assignees to an issue.
         Assignees are silently ignored otherwise.
 
+    .PARAMETER PassThru
+        Returns the updated GitHub Issue.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -346,6 +351,8 @@ function Add-GitHubAssignee
         [Alias('UserName')]
         [string[]] $Assignee,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -397,7 +404,11 @@ function Add-GitHubAssignee
             return
         }
 
-        return (Invoke-GHRestMethod @params | Add-GitHubIssueAdditionalProperties)
+        $result = (Invoke-GHRestMethod @params | Add-GitHubIssueAdditionalProperties)
+        if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+        {
+            return $result
+        }
     }
 }
 

--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -79,6 +79,13 @@ function Set-GitHubConfiguration
         The owner name that should be used with a command that takes OwnerName as a parameter
         when no value has been supplied.
 
+    .PARAMETER DefaultPassThru
+        Sets what the default PassThru behavior should be for commands that have a PassThru
+        switch.  By default, those commands will not return the result of the command unless
+        the user passes in -PassThru.  By setting this value to $true, those commands will
+        always behave as if -PassThru had been specified, unless you explicitly specify
+        -PassThru:$false on an individual command.
+
     .PARAMETER DefaultRepositoryName
         The owner name that should be used with a command that takes RepositoryName as a parameter
         when no value has been supplied.
@@ -196,6 +203,8 @@ function Set-GitHubConfiguration
 
         [string] $DefaultOwnerName,
 
+        [string] $DefaultPassThru,
+
         [string] $DefaultRepositoryName,
 
         [switch] $DisableLogging,
@@ -299,6 +308,7 @@ function Get-GitHubConfiguration
             'ApiHostName',
             'ApplicationInsightsKey',
             'DefaultOwnerName',
+            'DefaultPassThru',
             'DefaultRepositoryName',
             'DisableLogging',
             'DisablePiiProtection',
@@ -656,6 +666,7 @@ function Import-GitHubConfiguration
         'disableTelemetry' = $false
         'disableUpdateCheck' = $false
         'defaultOwnerName' = [String]::Empty
+        'defaultPassThru' = $false
         'defaultRepositoryName' = [String]::Empty
         'logPath' = $logPath
         'logProcessId' = $false
@@ -835,6 +846,10 @@ function Resolve-ParameterWithDefaultConfigurationValue
     if ($BoundParameters.ContainsKey($Name))
     {
         $value = $BoundParameters[$Name]
+        if ($value -is [switch])
+        {
+            $value = $value.IsPresent
+        }
     }
     else
     {

--- a/GitHubContents.ps1
+++ b/GitHubContents.ps1
@@ -255,6 +255,11 @@ filter Set-GitHubContent
         The email of the author of the commit. Defaults to the email of the authenticated user if
         not specified. If specified, AuthorName must also be specified.
 
+    .PARAMETER PassThru
+        Returns the updated GitHub Content.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -334,6 +339,8 @@ filter Set-GitHubContent
         [string] $AuthorName,
 
         [string] $AuthorEmail,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -425,7 +432,11 @@ filter Set-GitHubContent
 
     try
     {
-        return (Invoke-GHRestMethod @params | Add-GitHubContentAdditionalProperties)
+        $result = (Invoke-GHRestMethod @params | Add-GitHubContentAdditionalProperties)
+        if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+        {
+            return $result
+        }
     }
     catch
     {
@@ -486,7 +497,11 @@ filter Set-GitHubContent
                 'of that file.  Retrieving the SHA now.'
             Write-Log -Level Verbose -Message $message
 
-            return (Invoke-GHRestMethod @params | Add-GitHubContentAdditionalProperties)
+            $result = (Invoke-GHRestMethod @params | Add-GitHubContentAdditionalProperties)
+            if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+            {
+                return $result
+            }
         }
     }
 }

--- a/GitHubGistComments.ps1
+++ b/GitHubGistComments.ps1
@@ -315,6 +315,11 @@ filter Set-GitHubGistComment
     .PARAMETER Body
         The new text of the comment that you wish to leave on the gist.
 
+    .PARAMETER PassThru
+        Returns the updated Comment.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -330,7 +335,7 @@ filter Set-GitHubGistComment
         GitHub.GistComment
 
     .EXAMPLE
-        New-GitHubGistComment -Gist 6cad326836d38bd3a7ae -Comment 1232456 -Body 'Hello World'
+        Set-GitHubGistComment -Gist 6cad326836d38bd3a7ae -Comment 1232456 -Body 'Hello World'
 
         Updates the body of the comment with ID 1232456 octocat's "hello_world.rb" gist to be
         "Hello World".
@@ -339,6 +344,7 @@ filter Set-GitHubGistComment
         SupportsShouldProcess,
         PositionalBinding = $false)]
     [OutputType({$script:GitHubGistCommentTypeName})]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -361,6 +367,8 @@ filter Set-GitHubGistComment
             Position = 3)]
         [ValidateNotNullOrEmpty()]
         [string] $Body,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -387,7 +395,11 @@ filter Set-GitHubGistComment
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubGistCommentAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubGistCommentAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Add-GitHubGistCommentAdditionalProperties

--- a/GitHubGists.ps1
+++ b/GitHubGists.ps1
@@ -519,6 +519,11 @@ filter Copy-GitHubGist
     .PARAMETER Gist
         The ID of the specific gist that you wish to fork.
 
+    .PARAMETER PassThru
+        Returns the newly created gist fork.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -539,16 +544,18 @@ filter Copy-GitHubGist
         Forks octocat's "hello_world.rb" gist.
 
     .EXAMPLE
-        Fork-GitHubGist -Gist 6cad326836d38bd3a7ae
+        $result = Fork-GitHubGist -Gist 6cad326836d38bd3a7ae -PassThru
 
         Forks octocat's "hello_world.rb" gist.  This is using the alias for the command.
         The result is the same whether you use Copy-GitHubGist or Fork-GitHubGist.
+        Specifying the -PassThru switch enables you to get a reference to the newly created fork.
 #>
     [CmdletBinding(
         SupportsShouldProcess,
         PositionalBinding = $false)]
     [OutputType({$script:GitHubGistSummaryTypeName})]
     [Alias('Fork-GitHubGist')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -557,6 +564,8 @@ filter Copy-GitHubGist
         [Alias('GistId')]
         [ValidateNotNullOrEmpty()]
         [string] $Gist,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -578,8 +587,13 @@ filter Copy-GitHubGist
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params |
+    $result = (Invoke-GHRestMethod @params |
         Add-GitHubGistAdditionalProperties -TypeName $script:GitHubGistSummaryTypeName)
+
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Set-GitHubGistStar
@@ -1075,6 +1089,11 @@ filter Set-GitHubGist
     .PARAMETER Force
         If this switch is specified, you will not be prompted for confirmation of command execution.
 
+    .PARAMETER PassThru
+        Returns the updated gist.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -1119,6 +1138,7 @@ filter Set-GitHubGist
         DefaultParameterSetName='Content',
         PositionalBinding = $false)]
     [OutputType({$script:GitHubGistTypeName})]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -1135,6 +1155,8 @@ filter Set-GitHubGist
         [string] $Description,
 
         [switch] $Force,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -1231,8 +1253,13 @@ filter Set-GitHubGist
 
     try
     {
-        return (Invoke-GHRestMethod @params |
+        $result = (Invoke-GHRestMethod @params |
             Add-GitHubGistAdditionalProperties -TypeName $script:GitHubGistTypeName)
+
+        if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+        {
+            return $result
+        }
     }
     catch
     {
@@ -1275,6 +1302,11 @@ function Set-GitHubGistFile
     .PARAMETER Content
         The content of a single file that should be part of the gist.
 
+    .PARAMETER PassThru
+        Returns the updated gist.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -1314,6 +1346,7 @@ function Set-GitHubGistFile
     [OutputType({$script:GitHubGistTypeName})]
     [Alias('Add-GitHubGistFile')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="This is a helper method for Set-GitHubGist which will handle ShouldProcess.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -1344,6 +1377,8 @@ function Set-GitHubGistFile
             Position = 3)]
         [ValidateNotNullOrEmpty()]
         [string] $Content,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -1383,6 +1418,7 @@ function Set-GitHubGistFile
         $params = @{
             'Gist' = $Gist
             'Update' = $files
+            'PassThru' = (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
             'AccessToken' = $AccessToken
         }
 
@@ -1411,6 +1447,11 @@ function Remove-GitHubGistFile
 
     .PARAMETER Force
         If this switch is specified, you will not be prompted for confirmation of command execution.
+
+    .PARAMETER PassThru
+        Returns the updated gist.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
 
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
@@ -1447,6 +1488,7 @@ function Remove-GitHubGistFile
     [OutputType({$script:GitHubGistTypeName})]
     [Alias('Delete-GitHubGistFile')]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="This is a helper method for Set-GitHubGist which will handle ShouldProcess.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -1464,6 +1506,8 @@ function Remove-GitHubGistFile
         [string[]] $FileName,
 
         [switch] $Force,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -1491,6 +1535,7 @@ function Remove-GitHubGistFile
             'Delete' = $files
             'Force' = $Force
             'Confirm' = ($Confirm -eq $true)
+            'PassThru' = (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
             'AccessToken' = $AccessToken
         }
 
@@ -1520,6 +1565,11 @@ filter Rename-GitHubGistFile
     .PARAMETER NewName
         The new name of the file for the gist.
 
+    .PARAMETER PassThru
+        Returns the updated gist.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -1544,6 +1594,7 @@ filter Rename-GitHubGistFile
         PositionalBinding = $false)]
     [OutputType({$script:GitHubGistTypeName})]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSShouldProcess", "", Justification="This is a helper method for Set-GitHubGist which will handle ShouldProcess.")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -1565,6 +1616,8 @@ filter Rename-GitHubGistFile
         [ValidateNotNullOrEmpty()]
         [string] $NewName,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -1574,6 +1627,7 @@ filter Rename-GitHubGistFile
     $params = @{
         'Gist' = $Gist
         'Update' = @{$FileName = @{ 'fileName' = $NewName }}
+        'PassThru' = (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
         'AccessToken' = $AccessToken
     }
 

--- a/GitHubIssueComments.ps1
+++ b/GitHubIssueComments.ps1
@@ -451,6 +451,11 @@ filter Set-GitHubIssueComment
         Full - Return raw, text and HTML representations.
                Response will include body, body_text, and body_html.
 
+    .PARAMETER PassThru
+        Returns the updated Comment.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -513,6 +518,8 @@ filter Set-GitHubIssueComment
         [ValidateSet('Raw', 'Text', 'Html', 'Full')]
         [string] $MediaType ='Raw',
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -548,7 +555,11 @@ filter Set-GitHubIssueComment
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubIssueCommentAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubIssueCommentAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubIssueComment

--- a/GitHubIssues.ps1
+++ b/GitHubIssues.ps1
@@ -692,6 +692,11 @@ filter Set-GitHubIssue
         Full - Return raw, text and HTML representations.
                Response will include body, body_text, and body_html.
 
+    .PARAMETER PassThru
+        Returns the updated Issue.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -760,6 +765,8 @@ filter Set-GitHubIssue
         [ValidateSet('Raw', 'Text', 'Html', 'Full')]
         [string] $MediaType ='Raw',
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -806,7 +813,11 @@ filter Set-GitHubIssue
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubIssueAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubIssueAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Lock-GitHubIssue

--- a/GitHubLabels.ps1
+++ b/GitHubLabels.ps1
@@ -508,6 +508,11 @@ filter Set-GitHubLabel
     .PARAMETER Description
         A short description of the label.
 
+    .PARAMETER PassThru
+        Returns the updated Label.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -572,6 +577,8 @@ filter Set-GitHubLabel
 
         [string] $Description,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -614,7 +621,11 @@ filter Set-GitHubLabel
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubLabelAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubLabelAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Initialize-GitHubLabel
@@ -808,6 +819,11 @@ function Add-GitHubIssueLabel
     .PARAMETER Label
         Array of label names to add to the issue
 
+    .PARAMETER PassThru
+        Returns the added Label.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -881,6 +897,8 @@ function Add-GitHubIssueLabel
         [ValidateNotNullOrEmpty()]
         [string[]] $Label,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -931,7 +949,11 @@ function Add-GitHubIssueLabel
             'TelemetryProperties' = $telemetryProperties
         }
 
-        return (Invoke-GHRestMethod @params | Add-GitHubLabelAdditionalProperties)
+        $result = (Invoke-GHRestMethod @params | Add-GitHubLabelAdditionalProperties)
+        if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+        {
+            return $result
+        }
     }
 }
 
@@ -964,6 +986,11 @@ function Set-GitHubIssueLabel
 
     .PARAMETER Force
         If this switch is specified, you will not be prompted for confirmation of command execution.
+
+    .PARAMETER PassThru
+        Returns the updated Label.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
 
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
@@ -1056,6 +1083,8 @@ function Set-GitHubIssueLabel
 
         [switch] $Force,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -1119,7 +1148,11 @@ function Set-GitHubIssueLabel
             'TelemetryProperties' = $telemetryProperties
         }
 
-        return (Invoke-GHRestMethod @params | Add-GitHubLabelAdditionalProperties)
+        $result = (Invoke-GHRestMethod @params | Add-GitHubLabelAdditionalProperties)
+        if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+        {
+            return $result
+        }
     }
 }
 

--- a/GitHubMilestones.ps1
+++ b/GitHubMilestones.ps1
@@ -415,6 +415,11 @@ filter Set-GitHubMilestone
         GitHub will drop any time provided with this value, therefore please ensure that the
         UTC version of this value has your desired date.
 
+    .PARAMETER PassThru
+        Returns the updated Milestone.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -503,6 +508,8 @@ filter Set-GitHubMilestone
 
         [DateTime] $DueOn,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -562,7 +569,11 @@ filter Set-GitHubMilestone
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubMilestoneAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubMilestoneAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubMilestone

--- a/GitHubProjectCards.ps1
+++ b/GitHubProjectCards.ps1
@@ -278,6 +278,11 @@ filter Set-GitHubProjectCard
     .PARAMETER Restore
         Restore a project card.
 
+    .PARAMETER PassThru
+        Returns the updated Project Card.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -322,6 +327,8 @@ filter Set-GitHubProjectCard
 
         [Parameter(ParameterSetName = 'Restore')]
         [switch] $Restore,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -369,7 +376,11 @@ filter Set-GitHubProjectCard
         'AcceptHeader' = $script:inertiaAcceptHeader
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubProjectCardAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubProjectCardAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubProjectCard

--- a/GitHubProjectColumns.ps1
+++ b/GitHubProjectColumns.ps1
@@ -194,6 +194,11 @@ filter Set-GitHubProjectColumn
     .PARAMETER Name
         The name for the column.
 
+    .PARAMETER PassThru
+        Returns the updated Project Column.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -212,6 +217,7 @@ filter Set-GitHubProjectColumn
 #>
     [CmdletBinding(SupportsShouldProcess)]
     [OutputType({$script:GitHubProjectColumnTypeName})]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSReviewUnusedParameter", "", Justification="PassThru is accessed indirectly via Resolve-ParameterWithDefaultConfigurationValue")]
     param(
         [Parameter(
             Mandatory,
@@ -222,6 +228,8 @@ filter Set-GitHubProjectColumn
         [Parameter(Mandatory)]
         [Alias('Name')]
         [string] $ColumnName,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -253,7 +261,11 @@ filter Set-GitHubProjectColumn
         'AcceptHeader' = $script:inertiaAcceptHeader
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubProjectColumnAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubProjectColumnAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubProjectColumn

--- a/GitHubProjects.ps1
+++ b/GitHubProjects.ps1
@@ -419,6 +419,11 @@ filter Set-GitHubProject
         Only available for organization and user projects.
         Note: Updating a project's visibility requires admin access to the project.
 
+    .PARAMETER PassThru
+        Returns the updated Project.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -474,6 +479,8 @@ filter Set-GitHubProject
 
         [switch] $Private,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -526,7 +533,11 @@ filter Set-GitHubProject
         'AcceptHeader' = $script:inertiaAcceptHeader
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubProjectAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubProjectAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubProject

--- a/GitHubReactions.ps1
+++ b/GitHubReactions.ps1
@@ -236,6 +236,11 @@ filter Set-GitHubReaction
         The type of reaction you want to set. This is aslo called the 'content' in the GitHub API.
         Valid options are based off: https://developer.github.com/v3/reactions/#reaction-types
 
+    .PARAMETER PassThru
+        Returns the updated Reaction.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -331,6 +336,8 @@ filter Set-GitHubReaction
         [Parameter(Mandatory)]
         [string] $ReactionType,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -386,9 +393,13 @@ filter Set-GitHubReaction
         'TelemetryProperties' = $telemetryProperties
     }
 
-    $result = Invoke-GHRestMethod @params
+    $result = (Invoke-GHRestMethod @params |
+        Add-GitHubReactionAdditionalProperties @splatForAddedProperties)
 
-    return ($result | Add-GitHubReactionAdditionalProperties @splatForAddedProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubReaction

--- a/GitHubReleases.ps1
+++ b/GitHubReleases.ps1
@@ -424,6 +424,11 @@ filter Set-GitHubRelease
     .PARAMETER PreRelease
         Indicates if this should be identified as a pre-release or as a full release.
 
+    .PARAMETER PassThru
+        Returns the updated GitHub Release.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -495,6 +500,8 @@ filter Set-GitHubRelease
 
         [switch] $PreRelease,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -538,7 +545,11 @@ filter Set-GitHubRelease
         return
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubReleaseAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubReleaseAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubRelease
@@ -1124,6 +1135,11 @@ filter Set-GitHubReleaseAsset
     .PARAMETER Label
         An alternate short description of the asset.  Used in place of the filename.
 
+    .PARAMETER PassThru
+        Returns the updated Release Asset.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -1185,6 +1201,8 @@ filter Set-GitHubReleaseAsset
 
         [string] $Label,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -1220,7 +1238,11 @@ filter Set-GitHubReleaseAsset
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubReleaseAssetAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubReleaseAssetAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubReleaseAsset

--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -888,6 +888,11 @@ filter Rename-GitHubRepository
     .PARAMETER Force
         If this switch is specified, you will not be prompted for confirmation of command execution.
 
+    .PARAMETER PassThru
+        Returns the renamed Repository.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -977,6 +982,8 @@ filter Rename-GitHubRepository
 
         [switch] $Force,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -1061,6 +1068,11 @@ filter Set-GitHubRepository
     .PARAMETER Force
         If this switch is specified, you will not be prompted for confirmation of command execution
         when renaming the repository.
+
+    .PARAMETER PassThru
+        Returns the updated GitHub Repository.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
 
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
@@ -1153,6 +1165,8 @@ filter Set-GitHubRepository
 
         [switch] $Force,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -1212,7 +1226,11 @@ filter Set-GitHubRepository
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubRepositoryAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubRepositoryAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Get-GitHubRepositoryTopic
@@ -1344,6 +1362,11 @@ function Set-GitHubRepositoryTopic
     .PARAMETER Clear
         Specify this to clear all topics from the repository.
 
+    .PARAMETER PassThru
+        Returns the updated Repository Topics.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -1427,6 +1450,8 @@ function Set-GitHubRepositoryTopic
             ParameterSetName='UriClear')]
         [switch] $Clear,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -1488,8 +1513,12 @@ function Set-GitHubRepositoryTopic
             'TelemetryProperties' = $telemetryProperties
         }
 
-        return (Invoke-GHRestMethod @params |
+        $result = (Invoke-GHRestMethod @params |
             Add-GitHubRepositoryAdditionalProperties -TypeName $script:GitHubRepositoryTopicTypeName -OwnerName $OwnerName -RepositoryName $RepositoryName)
+        if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+        {
+            return $result
+        }
     }
 }
 
@@ -1982,6 +2011,11 @@ filter Move-GitHubRepositoryOwnership
         ID of the team or teams to add to the repository.  Teams can only be added to
         organization-owned repositories.
 
+    .PARAMETER PassThru
+        Returns the updated GitHub Repository.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -2035,6 +2069,8 @@ filter Move-GitHubRepositoryOwnership
 
         [int64[]] $TeamId,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -2072,7 +2108,11 @@ filter Move-GitHubRepositoryOwnership
         'TelemetryProperties' = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubRepositoryAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubRepositoryAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Test-GitHubRepositoryVulnerabilityAlert

--- a/GitHubTeams.ps1
+++ b/GitHubTeams.ps1
@@ -500,6 +500,11 @@ filter Set-GitHubTeam
     .PARAMETER ParentTeamName
         The name of a team to set as the parent team.
 
+    .PARAMETER PassThru
+        Returns the updated GitHub Team.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -549,6 +554,8 @@ filter Set-GitHubTeam
         [string] $Privacy,
 
         [string] $ParentTeamName,
+
+        [switch] $PassThru,
 
         [string] $AccessToken
     )
@@ -602,7 +609,11 @@ filter Set-GitHubTeam
         TelemetryProperties = $telemetryProperties
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubTeamAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubTeamAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Remove-GitHubTeam

--- a/GitHubUsers.ps1
+++ b/GitHubUsers.ps1
@@ -307,6 +307,11 @@ function Set-GitHubProfile
         Specify to indicate a change in hireable availability for the current authenticated user's
         GitHub profile.  To change to "not hireable", specify -Hireable:$false
 
+    .PARAMETER PassThru
+        Returns the updated User Profile.  By default, this cmdlet does not generate any output.
+        You can use "Set-GitHubConfiguration -DefaultPassThru" to control the default behavior
+        of this switch.
+
     .PARAMETER AccessToken
         If provided, this will be used as the AccessToken for authentication with the
         REST Api.  Otherwise, will attempt to use the configured value or will run unauthenticated.
@@ -338,6 +343,8 @@ function Set-GitHubProfile
 
         [switch] $Hireable,
 
+        [switch] $PassThru,
+
         [string] $AccessToken
     )
 
@@ -366,7 +373,11 @@ function Set-GitHubProfile
         'TelemetryEventName' = $MyInvocation.MyCommand.Name
     }
 
-    return (Invoke-GHRestMethod @params | Add-GitHubUserAdditionalProperties)
+    $result = (Invoke-GHRestMethod @params | Add-GitHubUserAdditionalProperties)
+    if (Resolve-ParameterWithDefaultConfigurationValue -Name PassThru -ConfigValueName DefaultPassThru)
+    {
+        return $result
+    }
 }
 
 filter Add-GitHubUserAdditionalProperties

--- a/Tests/GitHubAssignees.tests.ps1
+++ b/Tests/GitHubAssignees.tests.ps1
@@ -113,7 +113,7 @@ try
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
-            $updatedIssue = Add-GitHubAssignee -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $issue.number -Assignee $owner.login
+            $updatedIssue = Add-GitHubAssignee -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $issue.number -Assignee $owner.login -PassThru
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number
@@ -152,7 +152,7 @@ try
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
-            $updatedIssue = $repo | Add-GitHubAssignee -Issue $issue.number -Assignee $owner.login
+            $updatedIssue = $repo | Add-GitHubAssignee -Issue $issue.number -Assignee $owner.login -PassThru
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number
@@ -191,7 +191,7 @@ try
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
-            $updatedIssue = $issue | Add-GitHubAssignee -Assignee $owner.login
+            $updatedIssue = $issue | Add-GitHubAssignee -Assignee $owner.login -PassThru
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number
@@ -230,7 +230,7 @@ try
                 $issue.assignees | Should -BeNullOrEmpty
             }
 
-            $updatedIssue = $owner | Add-GitHubAssignee -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $issue.number
+            $updatedIssue = $owner | Add-GitHubAssignee -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $issue.number -PassThru
 
             It 'Should have returned the same issue' {
                 $updatedIssue.number | Should -Be $issue.number

--- a/Tests/GitHubContents.tests.ps1
+++ b/Tests/GitHubContents.tests.ps1
@@ -285,7 +285,7 @@ try
                     authorEmail = $authorEmail
                 }
 
-                $result = Set-GitHubContent @setGitHubContentParms
+                $result = Set-GitHubContent @setGitHubContentParms -PassThru
             }
 
             It 'Should have the expected type and additional properties' {
@@ -359,7 +359,7 @@ try
                     authorEmail = $authorEmail
                 }
 
-                $result = Set-GitHubContent @setGitHubContentParms
+                $result = Set-GitHubContent @setGitHubContentParms -PassThru
             }
 
             It 'Should have the expected type and additional properties' {

--- a/Tests/GitHubEvents.tests.ps1
+++ b/Tests/GitHubEvents.tests.ps1
@@ -45,7 +45,7 @@ try
 
         Context 'For getting Issue events from a repository' {
             $issue = $repo | New-GitHubIssue -Title 'New Issue'
-            $issue = $issue | Set-GitHubIssue -State Closed
+            $issue = $issue | Set-GitHubIssue -State Closed -PassThru
             $events = @($repo | Get-GitHubEvent)
 
             It 'Should have an event from closing an issue' {
@@ -82,8 +82,8 @@ try
         }
 
         Context 'For getting events from an issue' {
-            $issue = $issue | Set-GitHubIssue -State Closed
-            $issue = $issue | Set-GitHubIssue -State Open
+            $issue = $issue | Set-GitHubIssue -State Closed -PassThru
+            $issue = $issue | Set-GitHubIssue -State Open -PassThru
             $events = @(Get-GitHubEvent -OwnerName $ownerName -RepositoryName $repositoryName)
 
             It 'Should have two events from closing and opening the issue' {
@@ -98,8 +98,8 @@ try
             $repositoryName = [Guid]::NewGuid()
             $repo = New-GitHubRepository -RepositoryName $repositoryName
             $issue = $repo | New-GitHubIssue -Title 'New Issue'
-            $issue = $issue | Set-GitHubIssue -State Closed
-            $issue = $issue | Set-GitHubIssue -State Open
+            $issue = $issue | Set-GitHubIssue -State Closed -PassThru
+            $issue = $issue | Set-GitHubIssue -State Open -PassThru
             $events = @($repo | Get-GitHubEvent)
         }
 

--- a/Tests/GitHubGistComments.tests.ps1
+++ b/Tests/GitHubGistComments.tests.ps1
@@ -234,7 +234,7 @@ try
                 $comment.body | Should -Be $body
             }
 
-            $comment = Set-GitHubGistComment -Gist $gist.id -Comment $comment.id -Body $updatedBody
+            $comment = Set-GitHubGistComment -Gist $gist.id -Comment $comment.id -Body $updatedBody -PassThru
             It 'Should have the expected result' {
                 $comment.body | Should -Be $updatedBody
             }
@@ -253,7 +253,7 @@ try
                 $comment.body | Should -Be $body
             }
 
-            $comment = $gist | Set-GitHubGistComment -Comment $comment.id -Body $updatedBody
+            $comment = $gist | Set-GitHubGistComment -Comment $comment.id -Body $updatedBody -PassThru
             It 'Should have the expected result' {
                 $comment.body | Should -Be $updatedBody
             }
@@ -272,7 +272,7 @@ try
                 $comment.body | Should -Be $body
             }
 
-            $comment = $comment | Set-GitHubGistComment -Body $updatedBody
+            $comment = $comment | Set-GitHubGistComment -Body $updatedBody -PassThru
             It 'Should have the expected result' {
                 $comment.body | Should -Be $updatedBody
             }

--- a/Tests/GitHubGists.tests.ps1
+++ b/Tests/GitHubGists.tests.ps1
@@ -462,7 +462,7 @@ try
         }
 
         Context 'By parameters' {
-            $gist = Copy-GitHubGist -Gist $originalGist.id
+            $gist = Copy-GitHubGist -Gist $originalGist.id -PassThru
             It 'Should have been forked' {
                 $gist.files.Count | Should -Be $originalGist.files.Count
                 foreach ($file in $gist.files)
@@ -486,7 +486,7 @@ try
         }
 
         Context 'Gist on the pipeline' {
-            $gist = $originalGist | Copy-GitHubGist
+            $gist = $originalGist | Copy-GitHubGist -PassThru
             It 'Should have been forked' {
                 $gist.files.Count | Should -Be $originalGist.files.Count
                 foreach ($file in $gist.files)
@@ -736,7 +736,7 @@ try
                 $gist | Remove-GitHubGist -Force
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $fileBName -Content $fileBContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $fileBName -Content $fileBContent -PassThru
             It 'Should be in the expected, original state' {
                 $gist.description | Should -Be $description
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
@@ -758,7 +758,7 @@ try
                 }
             }
 
-            $gist = Set-GitHubGist @setParams -Force
+            $gist = Set-GitHubGist @setParams -Force -PassThru
             It 'Should have been properly updated' {
                 $gist.description | Should -Be $updatedDescription
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 3
@@ -799,7 +799,7 @@ try
                 $gist | Remove-GitHubGist -Force
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $fileBName -Content $fileBContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $fileBName -Content $fileBContent -PassThru
             It 'Should be in the expected, original state' {
                 $gist.description | Should -Be $description
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
@@ -820,7 +820,7 @@ try
                 }
             }
 
-            $gist = $gist | Set-GitHubGist @setParams -Confirm:$false
+            $gist = $gist | Set-GitHubGist @setParams -Confirm:$false -PassThru
             It 'Should have been properly updated' {
                 $gist.description | Should -Be $updatedDescription
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 3
@@ -869,7 +869,7 @@ try
         }
 
         Context 'By content with parameters' {
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $updatedOrigContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $updatedOrigContent -PassThru
             It 'Should have the expected result' {
                 $gist.files.$origFileName.content | Should -Be $updatedOrigContent
                 $gist.files.$newFileName | Should -BeNullOrEmpty
@@ -881,7 +881,7 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $newFileName -Content $newContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $newFileName -Content $newContent -PassThru
             It 'Should have the expected result' {
                 $gist.files.$origFileName.content | Should -Be $updatedOrigContent
                 $gist.files.$newFileName.content | Should -Be $newContent
@@ -893,14 +893,14 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent -PassThru
             It 'Should remove the new file' {
                 { $gist | Remove-GitHubGistFile -FileName $newFileName -Force } | Should -Not -Throw
             }
         }
 
         Context 'By content with the gist on the pipeline' {
-            $gist = $gist | Set-GitHubGistFile -FileName $origFileName -Content $updatedOrigContent
+            $gist = $gist | Set-GitHubGistFile -FileName $origFileName -Content $updatedOrigContent -PassThru
             It 'Should have the expected result' {
                 $gist.files.$origFileName.content | Should -Be $updatedOrigContent
                 $gist.files.$newFileName | Should -BeNullOrEmpty
@@ -912,7 +912,7 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = $gist | Set-GitHubGistFile -FileName $newFileName -Content $newContent
+            $gist = $gist | Set-GitHubGistFile -FileName $newFileName -Content $newContent -PassThru
             It 'Should have the expected result' {
                 $gist.files.$origFileName.content | Should -Be $updatedOrigContent
                 $gist.files.$newFileName.content | Should -Be $newContent
@@ -924,7 +924,7 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent -PassThru
             It 'Should remove the new file' {
                 { $gist | Remove-GitHubGistFile -FileName $newFileName -Force } | Should -Not -Throw
             }
@@ -945,7 +945,7 @@ try
                 @($fileA) | Remove-Item -Force -ErrorAction SilentlyContinue | Out-Null
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -File $fileA
+            $gist = Set-GitHubGistFile -Gist $gist.id -File $fileA -PassThru
             It 'Should have the expected result' {
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
                 $gist.files.$origFileName.content | Should -Be $origContent
@@ -959,7 +959,7 @@ try
             }
 
             Out-File -FilePath $fileA -InputObject $fileAUpdatedContent -Encoding utf8
-            $gist = Set-GitHubGistFile -Gist $gist.id -File $fileA
+            $gist = Set-GitHubGistFile -Gist $gist.id -File $fileA -PassThru
             It 'Should have the expected result' {
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
                 $gist.files.$origFileName.content | Should -Be $origContent
@@ -972,7 +972,7 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent -PassThru
             It 'Should remove the new file' {
                 { $gist | Remove-GitHubGistFile -FileName $fileAName -Force } | Should -Not -Throw
             }
@@ -993,7 +993,7 @@ try
                 @($fileA) | Remove-Item -Force -ErrorAction SilentlyContinue | Out-Null
             }
 
-            $gist = $gist | Set-GitHubGistFile -File $fileA
+            $gist = $gist | Set-GitHubGistFile -File $fileA -PassThru
             It 'Should have the expected result' {
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
                 $gist.files.$origFileName.content | Should -Be $origContent
@@ -1007,7 +1007,7 @@ try
             }
 
             Out-File -FilePath $fileA -InputObject $fileAUpdatedContent -Encoding utf8
-            $gist = $gist | Set-GitHubGistFile -File $fileA
+            $gist = $gist | Set-GitHubGistFile -File $fileA -PassThru
             It 'Should have the expected result' {
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
                 $gist.files.$origFileName.content | Should -Be $origContent
@@ -1020,7 +1020,7 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent -PassThru
             It 'Should remove the new file' {
                 { $gist | Remove-GitHubGistFile -FileName $fileAName -Force } | Should -Not -Throw
             }
@@ -1041,7 +1041,7 @@ try
                 @($fileA) | Remove-Item -Force -ErrorAction SilentlyContinue | Out-Null
             }
 
-            $gist = $fileA | Set-GitHubGistFile -Gist $gist.id
+            $gist = $fileA | Set-GitHubGistFile -Gist $gist.id -PassThru
             It 'Should have the expected result' {
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
                 $gist.files.$origFileName.content | Should -Be $origContent
@@ -1055,7 +1055,7 @@ try
             }
 
             Out-File -FilePath $fileA -InputObject $fileAUpdatedContent -Encoding utf8
-            $gist = $fileA | Set-GitHubGistFile -Gist $gist.id
+            $gist = $fileA | Set-GitHubGistFile -Gist $gist.id -PassThru
             It 'Should have the expected result' {
                 ($gist.files | Get-Member -Type NoteProperty).Count | Should -Be 2
                 $gist.files.$origFileName.content | Should -Be $origContent
@@ -1068,7 +1068,7 @@ try
                 $gist.owner.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent
+            $gist = Set-GitHubGistFile -Gist $gist.id -FileName $origFileName -Content $origContent -PassThru
             It 'Should remove the new file' {
                 { $gist | Remove-GitHubGistFile -FileName $fileAName -Force } | Should -Not -Throw
             }
@@ -1089,7 +1089,7 @@ try
                 $gist.files.$newName | Should -BeNullOrEmpty
             }
 
-            $gist = Rename-GitHubGistFile -Gist $gist.id -FileName $originalName -NewName $newName
+            $gist = Rename-GitHubGistFile -Gist $gist.id -FileName $originalName -NewName $newName -PassThru
             It 'Should have been renamed' {
                 $gist.files.$originalName | Should -BeNullOrEmpty
                 $gist.files.$newName.content | Should -Be $content
@@ -1113,7 +1113,7 @@ try
                 $gist.files.$newName | Should -BeNullOrEmpty
             }
 
-            $gist = $gist | Rename-GitHubGistFile -FileName $originalName -NewName $newName
+            $gist = $gist | Rename-GitHubGistFile -FileName $originalName -NewName $newName -PassThru
             It 'Should have been renamed' {
                 $gist.files.$originalName | Should -BeNullOrEmpty
                 $gist.files.$newName.content | Should -Be $content
@@ -1143,7 +1143,7 @@ try
                 $gist.files.$fileName | Should -Not -BeNullOrEmpty
             }
 
-            $gist = Remove-GitHubGistFile -Gist $gist.id -FileName $fileName -Force
+            $gist = Remove-GitHubGistFile -Gist $gist.id -FileName $fileName -Force -PassThru
             It 'Should have been removed' {
                 $gist.files.$fileName | Should -BeNullOrEmpty
             }
@@ -1165,7 +1165,7 @@ try
                 $gist.files.$fileName | Should -Not -BeNullOrEmpty
             }
 
-            $gist = $gist | Remove-GitHubGistFile -FileName $fileName -Confirm:$false
+            $gist = $gist | Remove-GitHubGistFile -FileName $fileName -Confirm:$false -PassThru
             It 'Should have been removed' {
                 $gist.files.$fileName | Should -BeNullOrEmpty
             }

--- a/Tests/GitHubIssueComments.tests.ps1
+++ b/Tests/GitHubIssueComments.tests.ps1
@@ -64,7 +64,7 @@ try
             }
 
             $commentId = $result.id
-            $updated = Set-GitHubIssueComment -OwnerName $script:ownerName -RepositoryName $repo.name -Comment $commentId -Body $defaultEditedCommentBody
+            $updated = Set-GitHubIssueComment -OwnerName $script:ownerName -RepositoryName $repo.name -Comment $commentId -Body $defaultEditedCommentBody -PassThru
             It 'Should have modified the expected comment' {
                 $updated.id | Should -Be $commentId
             }
@@ -115,7 +115,7 @@ try
             }
 
             $commentId = $result.id
-            $updated = $repo | Set-GitHubIssueComment -Comment $commentId -Body $defaultEditedCommentBody
+            $updated = $repo | Set-GitHubIssueComment -Comment $commentId -Body $defaultEditedCommentBody -PassThru
             It 'Should have modified the expected comment' {
                 $updated.id | Should -Be $commentId
             }
@@ -166,7 +166,7 @@ try
             }
 
             $commentId = $result.id
-            $updated = Set-GitHubIssueComment -OwnerName $script:ownerName -RepositoryName $repo.name -Comment $commentId -Body $defaultEditedCommentBody
+            $updated = Set-GitHubIssueComment -OwnerName $script:ownerName -RepositoryName $repo.name -Comment $commentId -Body $defaultEditedCommentBody -PassThru
             It 'Should have modified the expected comment' {
                 $updated.id | Should -Be $commentId
             }
@@ -216,7 +216,7 @@ try
                 $result.user.PSObject.TypeNames[0] | Should -Be 'GitHub.User'
             }
 
-            $updated = $comment | Set-GitHubIssueComment -Body $defaultEditedCommentBody
+            $updated = $comment | Set-GitHubIssueComment -Body $defaultEditedCommentBody -PassThru
             It 'Should have modified the expected comment' {
                 $updated.id | Should -Be $comment.id
             }

--- a/Tests/GitHubIssues.tests.ps1
+++ b/Tests/GitHubIssues.tests.ps1
@@ -163,8 +163,8 @@ try
                 $newIssues += New-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Title ([Guid]::NewGuid().Guid)
             }
 
-            $newIssues[0] = Set-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[0].number -State Closed
-            $newIssues[-1] = Set-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[-1].number -State Closed
+            $newIssues[0] = Set-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[0].number -State Closed -PassThru
+            $newIssues[-1] = Set-GitHubIssue -OwnerName $script:ownerName -RepositoryName $repo.name -Issue $newIssues[-1].number -State Closed -PassThru
 
             $existingOpenIssues = @($existingIssues | Where-Object { $_.state -eq 'open' })
             $newOpenIssues = @($newIssues | Where-Object { $_.state -eq 'open' })
@@ -315,7 +315,7 @@ try
                 'MediaType' = 'Raw'
             }
 
-            $updated = Set-GitHubIssue @params
+            $updated = Set-GitHubIssue @params -PassThru
             It 'Should have the expected property values' {
                 $updated.id | Should -Be $issue.id
                 $updated.number | Should -Be $issue.number
@@ -363,7 +363,7 @@ try
                 'MediaType' = 'Raw'
             }
 
-            $updated = $repo | Set-GitHubIssue @params
+            $updated = $repo | Set-GitHubIssue @params -PassThru
             It 'Should have the expected property values' {
                 $updated.id | Should -Be $issue.id
                 $updated.number | Should -Be $issue.number
@@ -410,7 +410,7 @@ try
                 'MediaType' = 'Raw'
             }
 
-            $updated = $issue | Set-GitHubIssue @params
+            $updated = $issue | Set-GitHubIssue @params -PassThru
             It 'Should have the expected property values' {
                 $updated.id | Should -Be $issue.id
                 $updated.number | Should -Be $issue.number

--- a/Tests/GitHubLabels.tests.ps1
+++ b/Tests/GitHubLabels.tests.ps1
@@ -375,7 +375,7 @@ try
             $label = $repo | New-GitHubLabel -Label ([Guid]::NewGuid().Guid) -Color 'BBBBBB'
 
             $newColor = 'AAAAAA'
-            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Color $newColor
+            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Color $newColor -PassThru
 
             It 'Label should have different color' {
                 $result.name | Should -Be $label.name
@@ -395,7 +395,7 @@ try
             $label = $repo | New-GitHubLabel -Label ([Guid]::NewGuid().Guid) -Color 'BBBBBB'
 
             $newColor = '#AAAAAA'
-            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Color $newColor
+            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Color $newColor -PassThru
 
             It 'Label should have different color' {
                 $result.name | Should -Be $label.name
@@ -415,7 +415,7 @@ try
             $label = $repo | New-GitHubLabel -Label ([Guid]::NewGuid().Guid) -Color 'BBBBBB'
 
             $newName = [Guid]::NewGuid().Guid
-            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -NewName $newName
+            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -NewName $newName -PassThru
 
             It 'Label should have different name' {
                 $result.name | Should -Be $newName
@@ -435,7 +435,7 @@ try
             $label = $repo | New-GitHubLabel -Label ([Guid]::NewGuid().Guid) -Color 'BBBBBB' -Description 'test description'
 
             $newDescription = [Guid]::NewGuid().Guid
-            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Description $newDescription
+            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -Description $newDescription -PassThru
 
             It 'Label should have different name' {
                 $result.name | Should -Be $label.name
@@ -457,7 +457,7 @@ try
             $newName = [Guid]::NewGuid().Guid
             $newColor = 'AAAAAA'
             $newDescription = [Guid]::NewGuid().Guid
-            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -NewName $newName -Color $newColor -Description $newDescription
+            $result = Set-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $label.name -NewName $newName -Color $newColor -Description $newDescription -PassThru
 
             It 'Label should have different everything' {
                 $result.name | Should -Be $newName
@@ -479,7 +479,7 @@ try
             $label = $repo | New-GitHubLabel -Label ([Guid]::NewGuid().Guid) -Color 'BBBBBB'
 
             $newColor = 'AAAAAA'
-            $result = $repo | Set-GitHubLabel -Label $label.name -Color $newColor
+            $result = $repo | Set-GitHubLabel -Label $label.name -Color $newColor -PassThru
 
             It 'Label should have different color' {
                 $result.name | Should -Be $label.name
@@ -499,7 +499,7 @@ try
             $label = $repo | New-GitHubLabel -Label ([Guid]::NewGuid().Guid) -Color 'BBBBBB'
 
             $newName = [Guid]::NewGuid().Guid
-            $result = $label | Set-GitHubLabel -NewName $newName
+            $result = $label | Set-GitHubLabel -NewName $newName -PassThru
 
             It 'Label should have different name' {
                 $result.name | Should -Be $newName
@@ -521,7 +521,7 @@ try
             $newName = [Guid]::NewGuid().Guid
             $newColor = 'AAAAAA'
             $newDescription = [Guid]::NewGuid().Guid
-            $result = $label | Set-GitHubLabel -NewName $newName -Color $newColor -Description $newDescription
+            $result = $label | Set-GitHubLabel -NewName $newName -Color $newColor -Description $newDescription -PassThru
 
             It 'Label should have different everything' {
                 $result.name | Should -Be $newName
@@ -626,7 +626,7 @@ try
         Context 'Adding labels to an issue' {
             $expectedLabels = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[3].name)
             $issue = $repo | New-GitHubIssue -Title 'test issue'
-            $result = @(Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -LabelName $expectedLabels)
+            $result = @(Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -LabelName $expectedLabels -PassThru)
 
             It 'Should return the number of labels that were just added' {
                 $result.Count | Should -Be $expectedLabels.Count
@@ -669,7 +669,7 @@ try
         Context 'Adding labels to an issue with the repo on the pipeline' {
             $expectedLabels = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[3].name)
             $issue = $repo | New-GitHubIssue -Title 'test issue'
-            $result = @($repo | Add-GitHubIssueLabel -Issue $issue.number -LabelName $expectedLabels)
+            $result = @($repo | Add-GitHubIssueLabel -Issue $issue.number -LabelName $expectedLabels -PassThru)
 
             It 'Should return the number of labels that were just added' {
                 $result.Count | Should -Be $expectedLabels.Count
@@ -712,7 +712,7 @@ try
         Context 'Adding labels to an issue with the issue on the pipeline' {
             $expectedLabels = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[3].name)
             $issue = $repo | New-GitHubIssue -Title 'test issue'
-            $result = @($issue | Add-GitHubIssueLabel -LabelName $expectedLabels)
+            $result = @($issue | Add-GitHubIssueLabel -LabelName $expectedLabels -PassThru)
 
             It 'Should return the number of labels that were just added' {
                 $result.Count | Should -Be $expectedLabels.Count
@@ -755,7 +755,7 @@ try
         Context 'Adding labels to an issue with the label names on the pipeline' {
             $expectedLabels = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[3].name)
             $issue = $repo | New-GitHubIssue -Title 'test issue'
-            $result = @($expectedLabels | Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number)
+            $result = @($expectedLabels | Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -PassThru)
 
             It 'Should return the number of labels that were just added' {
                 $result.Count | Should -Be $expectedLabels.Count
@@ -799,7 +799,7 @@ try
             $expectedLabels = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[3].name)
             $issue = $repo | New-GitHubIssue -Title 'test issue'
             $labels = @($expectedLabels | ForEach-Object { Get-GitHubLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Label $_ } )
-            $result = @($labels | Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number)
+            $result = @($labels | Add-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -PassThru)
 
             It 'Should return the number of labels that were just added' {
                 $result.Count | Should -Be $expectedLabels.Count
@@ -922,7 +922,7 @@ try
             $issue = $repo | New-GitHubIssue -Title $issueName
 
             $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name)
-            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
             $issueLabels = @($issue | Get-GitHubLabel)
             It 'Should have the expected number of labels' {
@@ -945,7 +945,7 @@ try
             $issue = $repo | New-GitHubIssue -Title $issueName
 
             $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name, $defaultLabels[3].name)
-            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
             $issueLabels = @($issue | Get-GitHubLabel)
             It 'Should have the expected number of labels' {
@@ -967,7 +967,7 @@ try
             $issue = $repo | New-GitHubIssue -Title $issueName
 
             $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name, $defaultLabels[3].name)
-            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
             $issueLabels = @($issue | Get-GitHubLabel)
             It 'Should have the expected number of labels' {
@@ -992,7 +992,7 @@ try
         #     $issue = $repo | New-GitHubIssue -Title $issueName
 
         #     $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name, $defaultLabels[3].name)
-        #     $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+        #     $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
         #     $issueLabels = @($issue | Get-GitHubLabel)
         #     It 'Should have the expected number of labels' {
@@ -1014,7 +1014,7 @@ try
             $issue = $repo | New-GitHubIssue -Title $issueName
 
             $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name, $defaultLabels[3].name)
-            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
             $issueLabels = @($issue | Get-GitHubLabel)
             It 'Should have the expected number of labels' {
@@ -1037,7 +1037,7 @@ try
             $issue = $repo | New-GitHubIssue -Title $issueName
 
             $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name, $defaultLabels[3].name)
-            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
             $issueLabels = @($issue | Get-GitHubLabel)
             It 'Should have the expected number of labels' {
@@ -1057,7 +1057,7 @@ try
             $issue = $repo | New-GitHubIssue -Title $issueName
 
             $labelsToAdd = @($defaultLabels[0].name, $defaultLabels[1].name, $defaultLabels[2].name, $defaultLabels[3].name)
-            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd
+            $issue | Add-GitHubIssueLabel -LabelName $labelsToAdd -PassThru
 
             $issueLabels = @($issue | Get-GitHubLabel)
             It 'Should have the expected number of labels' {
@@ -1097,7 +1097,7 @@ try
             }
 
             $newIssueLabels = @($defaultLabels[0].name, $defaultLabels[5].name)
-            $result = @(Set-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -Label $newIssueLabels)
+            $result = @(Set-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -Label $newIssueLabels -PassThru)
 
             It 'Should have the expected labels' {
                 $result.labels.Count | Should -Be $newIssueLabels.Count
@@ -1131,7 +1131,7 @@ try
             }
 
             $newIssueLabels = @($defaultLabels[0].name, $defaultLabels[5].name)
-            $result = @($repo | Set-GitHubIssueLabel -Issue $issue.number -Label $newIssueLabels)
+            $result = @($repo | Set-GitHubIssueLabel -Issue $issue.number -Label $newIssueLabels -PassThru)
 
             It 'Should have the expected labels' {
                 $result.labels.Count | Should -Be $newIssueLabels.Count
@@ -1165,7 +1165,7 @@ try
             }
 
             $newIssueLabels = @($defaultLabels[0].name, $defaultLabels[5].name)
-            $result = @($issue | Set-GitHubIssueLabel -Label $newIssueLabels)
+            $result = @($issue | Set-GitHubIssueLabel -Label $newIssueLabels -PassThru)
 
             It 'Should have the expected labels' {
                 $result.labels.Count | Should -Be $newIssueLabels.Count
@@ -1200,7 +1200,7 @@ try
 
             $newIssueLabelNames = @($defaultLabels[0].name, $defaultLabels[5].name)
             $issueLabels = @($newIssueLabelNames | ForEach-Object { $repo | Get-GitHubLabel -Label $_ })
-            $result = @($issueLabels | Set-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number)
+            $result = @($issueLabels | Set-GitHubIssueLabel -OwnerName $script:ownerName -RepositoryName $repositoryName -Issue $issue.number -PassThru)
 
             It 'Should have the expected labels' {
                 $result.labels.Count | Should -Be $newIssueLabelNames.Count

--- a/Tests/GitHubMilestones.tests.ps1
+++ b/Tests/GitHubMilestones.tests.ps1
@@ -182,21 +182,21 @@ try
                 $milestone.open_issues | Should -Be 0
             }
 
-            $issue = $issue | Set-GitHubIssue -Milestone $milestone.MilestoneNumber
+            $issue = $issue | Set-GitHubIssue -Milestone $milestone.MilestoneNumber -PassThru
             $milestone = $milestone | Get-GitHubMilestone
             It "Should be associated to the milestone now" {
                 $issue.milestone.number | Should -Be $milestone.MilestoneNumber
                 $milestone.open_issues | Should -Be 1
             }
 
-            $issue = $issue | Set-GitHubIssue -Milestone 0
+            $issue = $issue | Set-GitHubIssue -Milestone 0 -PassThru
             $milestone = $milestone | Get-GitHubMilestone
             It 'Should no longer be associated to the milestone' {
                 $issue.milestone | Should -BeNullOrEmpty
                 $milestone.open_issues | Should -Be 0
             }
 
-            $issue = $issue | Set-GitHubIssue -Milestone $milestone.MilestoneNumber
+            $issue = $issue | Set-GitHubIssue -Milestone $milestone.MilestoneNumber -PassThru
             $milestone = $milestone | Get-GitHubMilestone
             It "Should be associated to the milestone again" {
                 $issue.milestone.number | Should -Be $milestone.MilestoneNumber
@@ -319,6 +319,7 @@ try
                 'State' = 'Closed'
                 'Description' = 'Edited Description'
                 'DueOn' = (Get-Date).AddDays(7).ToUniversalTime()
+                'PassThru' = $true
             }
         }
 

--- a/Tests/GitHubProjectCards.tests.ps1
+++ b/Tests/GitHubProjectCards.tests.ps1
@@ -45,7 +45,7 @@ try
         BeforeAll {
             $card = New-GitHubProjectCard -Column $column.id -Note $defaultCard
             $cardArchived = New-GitHubProjectCard -Column $column.id -Note $defaultArchivedCard
-            $null = Set-GitHubProjectCard -Card $cardArchived.id -Archive
+            Set-GitHubProjectCard -Card $cardArchived.id -Archive
         }
 
         AfterAll {
@@ -167,7 +167,7 @@ try
         }
 
         Context 'Modify card note' {
-            $null = Set-GitHubProjectCard -Card $card.id -Note $defaultCardUpdated
+            Set-GitHubProjectCard -Card $card.id -Note $defaultCardUpdated
             $result = Get-GitHubProjectCard -Card $card.id
 
             It 'Should get card' {
@@ -197,7 +197,7 @@ try
                 $result.note | Should -Be $defaultCardUpdated
             }
 
-            $null = $card | Set-GitHubProjectCard -Note $defaultCard
+            $card | Set-GitHubProjectCard -Note $defaultCard
             $result = $card | Get-GitHubProjectCard
 
             It 'Should have the updated Note' {
@@ -217,7 +217,7 @@ try
         }
 
         Context 'Archive a card' {
-            $null = Set-GitHubProjectCard -Card $cardArchived.id -Archive
+            Set-GitHubProjectCard -Card $cardArchived.id -Archive
             $result = Get-GitHubProjectCard -Card $cardArchived.id
 
             It 'Should get card' {
@@ -230,7 +230,7 @@ try
         }
 
         Context 'Restore a card' {
-            $null = $cardArchived | Set-GitHubProjectCard -Restore
+            $cardArchived | Set-GitHubProjectCard -Restore
             $result = Get-GitHubProjectCard -Card $cardArchived.id
 
             It 'Should get card' {

--- a/Tests/GitHubProjectColumns.tests.ps1
+++ b/Tests/GitHubProjectColumns.tests.ps1
@@ -125,7 +125,7 @@ try
         }
 
         Context 'Modify column name' {
-            $null = Set-GitHubProjectColumn -Column $column.id -ColumnName $defaultColumnUpdate
+            Set-GitHubProjectColumn -Column $column.id -ColumnName $defaultColumnUpdate
             $result = Get-GitHubProjectColumn -Column $column.id
 
             It 'Should get column' {

--- a/Tests/GitHubProjects.tests.ps1
+++ b/Tests/GitHubProjects.tests.ps1
@@ -146,7 +146,7 @@ try
         Context 'Get a closed Repo project (via pipeline)' {
             BeforeAll {
                 $project = $repo | New-GitHubProject -ProjectName $defaultProjectClosed -Description $defaultProjectClosedDesc
-                $null = Set-GitHubProject -Project $project.id -State Closed
+                Set-GitHubProject -Project $project.id -State Closed
             }
 
             AfterAll {
@@ -267,7 +267,7 @@ try
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
 
-            $null = Set-GitHubProject -Project $project.id -Description $modifiedUserProjectDesc
+            Set-GitHubProject -Project $project.id -Description $modifiedUserProjectDesc
             $result = Get-GitHubProject -Project $project.id
             It 'Should get project' {
                 $result | Should -Not -BeNullOrEmpty
@@ -298,7 +298,7 @@ try
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
 
-            $null = $project.id | Set-GitHubProject -Description $modifiedUserProjectDesc
+            $project.id | Set-GitHubProject -Description $modifiedUserProjectDesc
             $result = Get-GitHubProject -Project $project.id
             It 'Should get project' {
                 $result | Should -Not -BeNullOrEmpty
@@ -329,7 +329,7 @@ try
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
 
-            $null = $project | Set-GitHubProject -Description $modifiedUserProjectDesc
+            $project | Set-GitHubProject -Description $modifiedUserProjectDesc
             $result = Get-GitHubProject -Project $project.id
             It 'Should get project' {
                 $result | Should -Not -BeNullOrEmpty
@@ -360,7 +360,7 @@ try
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
 
-            $null = Set-GitHubProject -Project $project.id -Description $modifiedOrgProjectDesc -Private:$false -OrganizationPermission Admin
+            Set-GitHubProject -Project $project.id -Description $modifiedOrgProjectDesc -Private:$false -OrganizationPermission Admin
             $result = Get-GitHubProject -Project $project.id
             It 'Should get project' {
                 $result | Should -Not -BeNullOrEmpty
@@ -402,7 +402,7 @@ try
                 $null = Remove-GitHubProject -Project $project.id -Confirm:$false
             }
 
-            $null = Set-GitHubProject -Project $project.id -Description $modifiedRepoProjectDesc
+            Set-GitHubProject -Project $project.id -Description $modifiedRepoProjectDesc
             $result = Get-GitHubProject -Project $project.id
             It 'Should get project' {
                 $result | Should -Not -BeNullOrEmpty

--- a/Tests/GitHubReleases.tests.ps1
+++ b/Tests/GitHubReleases.tests.ps1
@@ -254,7 +254,7 @@ try
                 }
 
                 It 'Should be modifiable with the release on the pipeline' {
-                    $null = $release | Set-GitHubRelease -Name $defaultReleaseName -Body $defaultReleaseBody -Draft -PreRelease
+                    $release | Set-GitHubRelease -Name $defaultReleaseName -Body $defaultReleaseBody -Draft -PreRelease
                     $queried = $release | Get-GitHubRelease
                     $queried.name | Should -Be $defaultReleaseName
                     $queried.body | Should -Be $defaultReleaseBody
@@ -263,7 +263,7 @@ try
                 }
 
                 It 'Should be modifiable with the URI on the pipeline' {
-                    $null = $repo | Set-GitHubRelease -Release $release.id -Draft:$false
+                    $repo | Set-GitHubRelease -Release $release.id -Draft:$false
                     $queried = $repo | Get-GitHubRelease -Release $release.id
                     $queried.name | Should -Be $defaultReleaseName
                     $queried.body | Should -Be $defaultReleaseBody
@@ -782,6 +782,7 @@ try
                 OwnerName = $script:ownerName
                 RepositoryName = $repo.name
                 Asset = $asset.id
+                PassThru = $true
             }
 
             $updated = Set-GitHubReleaseAsset @setParams
@@ -806,6 +807,7 @@ try
                 RepositoryName = $repo.name
                 Asset = $asset.id
                 Name = $updatedFileName
+                PassThru = $true
             }
 
             $updated = Set-GitHubReleaseAsset @setParams
@@ -820,6 +822,7 @@ try
                 RepositoryName = $repo.name
                 Asset = $asset.id
                 Label = $updatedLabel
+                PassThru = $true
             }
 
             $updated = Set-GitHubReleaseAsset @setParams
@@ -836,6 +839,7 @@ try
                 Asset = $asset.id
                 Name = $updatedFileName
                 Label = $updatedLabel
+                PassThru = $true
             }
 
             $updated = Set-GitHubReleaseAsset @setParams
@@ -856,6 +860,7 @@ try
 
             $setParams = @{
                 Asset = $asset.id
+                PassThru = $true
             }
 
             $updated = $repo | Set-GitHubReleaseAsset @setParams
@@ -878,6 +883,7 @@ try
             $setParams = @{
                 Asset = $asset.id
                 Name = $updatedFileName
+                PassThru = $true
             }
 
             $updated = $repo | Set-GitHubReleaseAsset @setParams
@@ -890,6 +896,7 @@ try
             $setParams = @{
                 Asset = $asset.id
                 Label = $updatedLabel
+                PassThru = $true
             }
 
             $updated = $repo | Set-GitHubReleaseAsset @setParams
@@ -904,6 +911,7 @@ try
                 Asset = $asset.id
                 Name = $updatedFileName
                 Label = $updatedLabel
+                PassThru = $true
             }
 
             $updated = $repo | Set-GitHubReleaseAsset @setParams
@@ -924,6 +932,7 @@ try
 
             $setParams = @{
                 Asset = $asset.id
+                PassThru = $true
             }
 
             $updated = $release | Set-GitHubReleaseAsset @setParams
@@ -946,6 +955,7 @@ try
             $setParams = @{
                 Asset = $asset.id
                 Name = $updatedFileName
+                PassThru = $true
             }
 
             $updated = $release | Set-GitHubReleaseAsset @setParams
@@ -958,6 +968,7 @@ try
             $setParams = @{
                 Asset = $asset.id
                 Label = $updatedLabel
+                PassThru = $true
             }
 
             $updated = $release | Set-GitHubReleaseAsset @setParams
@@ -972,6 +983,7 @@ try
                 Asset = $asset.id
                 Name = $updatedFileName
                 Label = $updatedLabel
+                PassThru = $true
             }
 
             $updated = $release | Set-GitHubReleaseAsset @setParams
@@ -990,7 +1002,7 @@ try
                 $asset.label | Should -BeExactly $label
             }
 
-            $updated = $asset | Set-GitHubReleaseAsset
+            $updated = $asset | Set-GitHubReleaseAsset -PassThru
             It 'Should have the original property values' {
                 $updated.name | Should -BeExactly $fileName
                 $updated.label | Should -BeExactly $label
@@ -1007,14 +1019,14 @@ try
             }
 
             $updatedFileName = 'updated1.txt'
-            $updated = $asset | Set-GitHubReleaseAsset -Name $updatedFileName
+            $updated = $asset | Set-GitHubReleaseAsset -Name $updatedFileName -PassThru
             It 'Should have a new name and the original label' {
                 $updated.name | Should -BeExactly $updatedFileName
                 $updated.label | Should -BeExactly $label
             }
 
             $updatedLabel = 'updatedLabel2'
-            $updated = $asset | Set-GitHubReleaseAsset -Label $updatedLabel
+            $updated = $asset | Set-GitHubReleaseAsset -Label $updatedLabel -PassThru
             It 'Should have the current name and a new label' {
                 $updated.name | Should -BeExactly $updatedFileName
                 $updated.label | Should -BeExactly $updatedLabel
@@ -1022,7 +1034,7 @@ try
 
             $updatedFileName = 'updated3asset.txt'
             $updatedLabel = 'updatedLabel3asset'
-            $updated = $asset | Set-GitHubReleaseAsset -Name $updatedFileName -Label $updatedLabel
+            $updated = $asset | Set-GitHubReleaseAsset -Name $updatedFileName -Label $updatedLabel -PassThru
             It 'Should have a new name and a new label' {
                 $updated.name | Should -BeExactly $updatedFileName
                 $updated.label | Should -BeExactly $updatedLabel

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -679,23 +679,23 @@ try
             }
 
             It "Should have the expected new repository name - by URI" {
-                $renamedRepo = Rename-GitHubRepository -Uri ($repo.RepositoryUrl) -NewName $newRepoName -Force
+                $renamedRepo = Rename-GitHubRepository -Uri ($repo.RepositoryUrl) -NewName $newRepoName -Force -PassThru
                 $renamedRepo.name | Should -Be $newRepoName
             }
 
             It "Should have the expected new repository name - by Elements" {
-                $renamedRepo = Rename-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -NewName $newRepoName -Confirm:$false
+                $renamedRepo = Rename-GitHubRepository -OwnerName $repo.owner.login -RepositoryName $repo.name -NewName $newRepoName -Confirm:$false -PassThru
                 $renamedRepo.name | Should -Be $newRepoName
             }
 
             It "Should work via the pipeline" {
-                $renamedRepo = $repo | Rename-GitHubRepository -NewName $newRepoName -Confirm:$false
+                $renamedRepo = $repo | Rename-GitHubRepository -NewName $newRepoName -Confirm:$false -PassThru
                 $renamedRepo.name | Should -Be $newRepoName
                 $renamedRepo.PSObject.TypeNames[0] | Should -Be 'GitHub.Repository'
             }
 
             It "Should be possible to rename with Set-GitHubRepository too" {
-                $renamedRepo = $repo | Set-GitHubRepository -NewName $newRepoName -Confirm:$false
+                $renamedRepo = $repo | Set-GitHubRepository -NewName $newRepoName -Confirm:$false -PassThru
                 $renamedRepo.name | Should -Be $newRepoName
                 $renamedRepo.PSObject.TypeNames[0] | Should -Be 'GitHub.Repository'
             }
@@ -732,7 +732,7 @@ try
                         IsTemplate = $true
                     }
 
-                    $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms
+                    $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms -PassThru
                 }
 
                 It 'Should return an object of the correct type' {
@@ -765,7 +765,7 @@ try
                         DisallowRebaseMerge = $true
                     }
 
-                    $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms
+                    $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms -PassThru
                 }
 
                 It 'Should return an object of the correct type' {
@@ -788,7 +788,7 @@ try
                         Archived = $true
                     }
 
-                    $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms
+                    $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms -PassThru
                 }
 
                 It 'Should return an object of the correct type' {
@@ -820,7 +820,7 @@ try
                     Private = $false
                 }
 
-                $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms
+                $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms -PassThru
             }
 
             It 'Should return an object of the correct type' {
@@ -915,27 +915,26 @@ try
         Context -Name 'When getting a repository topic' {
             BeforeAll {
                 $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
-                Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Name $defaultRepoTopic |
-                    Out-Null
+                Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Name $defaultRepoTopic
                 $topic = Get-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
             }
 
             It 'Should have the expected topic' {
-                $null = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Topic $defaultRepoTopic
+                Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Topic $defaultRepoTopic
                 $topic = Get-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
 
                 $topic.names | Should -Be $defaultRepoTopic
             }
 
             It 'Should have no topics' {
-                $null = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Clear
+                Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Clear
                 $topic = Get-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
 
                 $topic.names | Should -BeNullOrEmpty
             }
 
             It 'Should have the expected topic (using repo via pipeline)' {
-                $null = $repo | Set-GitHubRepositoryTopic -Topic $defaultRepoTopic
+                $repo | Set-GitHubRepositoryTopic -Topic $defaultRepoTopic
                 $topic = $repo | Get-GitHubRepositoryTopic
 
                 $topic.names | Should -Be $defaultRepoTopic
@@ -944,7 +943,7 @@ try
             }
 
             It 'Should have the expected topic (using topic via pipeline)' {
-                $null = $defaultRepoTopic | Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
+                $defaultRepoTopic | Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
                 $topic = $repo | Get-GitHubRepositoryTopic
 
                 $topic.names | Should -Be $defaultRepoTopic
@@ -954,7 +953,7 @@ try
 
             It 'Should have the expected multi-topic (using topic via pipeline)' {
                 $topics = @('one', 'two')
-                $null = $topics | Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
+                $topics | Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name
                 $result = $repo | Get-GitHubRepositoryTopic
 
                 $result.PSObject.TypeNames[0] | Should -Be 'GitHub.RepositoryTopic'
@@ -975,7 +974,7 @@ try
     Describe 'GitHubRepositories\Set-GitHubRepositoryTopic' {
         BeforeAll {
             $repo = New-GitHubRepository -RepositoryName ([Guid]::NewGuid().Guid)
-            $topic = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Name $defaultRepoTopic
+            $topic = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Name $defaultRepoTopic -PassThru
         }
 
         Context -Name 'When setting a repository topic' {
@@ -990,7 +989,7 @@ try
 
         Context -Name 'When clearing all repository topics' {
             BeforeAll {
-                $topic = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Clear
+                $topic = Set-GitHubRepositoryTopic -OwnerName $repo.owner.login -RepositoryName $repo.name -Clear -PassThru
             }
 
             It 'Should return an object of the correct type' {

--- a/Tests/GitHubTeams.tests.ps1
+++ b/Tests/GitHubTeams.tests.ps1
@@ -534,7 +534,7 @@ try
                     ParentTeamName = $parentTeamName
                 }
 
-                $updatedTeam = Set-GitHubTeam @updateGitHubTeamParms
+                $updatedTeam = Set-GitHubTeam @updateGitHubTeamParms -PassThru
             }
 
             It 'Should have the expected type and additional properties' {
@@ -583,7 +583,7 @@ try
                     Privacy = $privacy
                 }
 
-                $updatedTeam = Set-GitHubTeam @updateGitHubTeamParms
+                $updatedTeam = Set-GitHubTeam @updateGitHubTeamParms -PassThru
             }
 
             It 'Should have the expected type and additional properties' {
@@ -622,7 +622,7 @@ try
 
                 $team = New-GitHubTeam -OrganizationName $organizationName -TeamName $teamName
 
-                $updatedTeam = $team | Set-GitHubTeam -Description $description
+                $updatedTeam = $team | Set-GitHubTeam -Description $description -PassThru
             }
 
             It 'Should have the expected type and additional properties' {

--- a/USAGE.md
+++ b/USAGE.md
@@ -4,6 +4,10 @@
 #### Table of Contents
 *   [Logging](#logging)
 *   [Telemetry](#telemetry)
+*   [Common PowerShell API Patterns](#common-powershell-api-patterns)
+    *   [Confirmation Required for Major Actions](#confirmation-required-for-major-actions)
+    *   [WhatIf Supported for All State Changing Commands](#whatif-supported-for-all-state-changing-commands)
+    *   [State Changing Commands are Silent by Default](#state-changing-commands-are-silent-by-default)
 *   [Examples](#examples)
     *   [Overview](#overview)
         *   [Embracing the pipeline](#embracing-the-pipeline)
@@ -208,6 +212,35 @@ Get-GitHubConfiguration -Name ApplicationInsightsKey
 ```
 It is requested that you do not change this value, otherwise the telemetry will not be reported to
 us for analysis.  We expose it here for complete transparency.
+
+----------
+
+## Common PowerShell API Patterns
+
+This module adopts many of the standard PowerShell API design patterns.  We want to call attention
+to those patterns here so that you can identify how you can most efficiently use the module.
+
+### Confirmation Required for Major Actions
+
+All commands that result in removing/deleting an object, as well as some commands that rename
+objects (like renaming a repository) require user confirmation before the comamnd will be processed.
+You can avoid that user confirmation by passing in either `-Confirm:$false` or `-Force`.
+
+### WhatIf Supported for All State Changing Commands
+
+Any command that _isn't_ `Get-GitHub*` supports the `-WhatIf` switch.  You can safely call that
+command by passing in the `-WhatIf` switch and know that the request will not actually be sent
+to GitHub.  This can be useful when paired with the `-Verbose` switch if you are examining what
+is happening behind the scenes.
+
+### State Changing Commands are Silent by Default
+
+By default, state changing commands like `Set-*`, `Rename-*`, etc... will not produce any output
+unless you specify the `-PassThru` switch.  You can change that default behavior by calling
+
+```powershell
+Set-GitHubConfiguration -DefaultPassThru:$true
+```
 
 ----------
 
@@ -603,7 +636,7 @@ Disable-GitHubRepositorySecurityFix -OwnerName microsoft -RepositoryName PowerSh
 #### Getting a repository branch protection rule
 
 ```powershell
-Get-GitHubRepositoryBranchProtectionRule -OwnerName microsoft -RepositoryName PowerShellForGitHub -BranchName master 
+Get-GitHubRepositoryBranchProtectionRule -OwnerName microsoft -RepositoryName PowerShellForGitHub -BranchName master
 ```
 
 #### Creating a repository branch protection rule


### PR DESCRIPTION
#### Description
All state-changing commands (with the exception of `New-*`) are now silent by default.  Users can pass-in `-PassThru` to make them return the result that used to be returned by default.

Users can revert back to the previous behavior by leveraging the new configuration value: `DefaultPassThru`.

#### Issues Fixed
Resolves #217 

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] Comment-based help added/updated, including examples.
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [x] ~~[Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.~~
- [x] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [x] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- [x] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).
- [x] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~