### PR TITLE
Fix default logPath when no user profile is available

### DIFF
--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -652,10 +652,10 @@ function Import-GitHubConfiguration
     $logPath = [String]::Empty
     $logName = 'PowerShellForGitHub.log'
     $documentsFolder = [System.Environment]::GetFolderPath('MyDocuments')
-    $logToTempFolder = [System.String]::IsNullOrEmpty($documentsFolder)
-    if ($logToTempFolder)
+    $logToLocalAppDataFolder = [System.String]::IsNullOrEmpty($documentsFolder)
+    if ($logToLocalAppDataFolder)
     {
-        $logPath = Join-Path -Path $env:TEMP -ChildPath $logName
+        $logPath = Join-Path -Path [Environment]::GetFolderPath('LocalApplicationData') -ChildPath $logName
     }
     else
     {
@@ -703,13 +703,14 @@ function Import-GitHubConfiguration
             $config.$name = Resolve-PropertyValue -InputObject $jsonObject -Name $name -Type $type -DefaultValue $config.$name
         }
 
-    # Quick verification for logPath
+    # Let the user know when we had to revert to using the LocalApplicationData folder for the
+    # log location (if they haven't already changed its path in their local config).
     $configuredLogPath = $config.logPath
-    if ($logToTempFolder -and ($logPath -eq $configuredLogPath))
+    if ($logToLocalAppDataFolder -and ($logPath -eq $configuredLogPath))
     {
         # Limited instance where we write the warning directly instead of using Write-Log, since
         # Write-Log won't yet be configured.
-        $message = "Default log location could not be determined.  Reverting to storing log at [$logPath].  You can change this location by calling Set-GitHubConfiguration -LogPath <desiredPathToLogFile>"
+        $message = "Storing log at non-default location: [$logPath] (no user profile path was found).  You can change this location by calling Set-GitHubConfiguration -LogPath <desiredPathToLogFile>"
         Write-Warning -Message $message
     }
 

--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -6,7 +6,7 @@
 
 # The location of the file that we'll store any settings that can/should roam with the user.
 [string] $script:configurationFilePath = [System.IO.Path]::Combine(
-    [Environment]::GetFolderPath('ApplicationData'),
+    [System.Environment]::GetFolderPath('ApplicationData'),
     'Microsoft',
     'PowerShellForGitHub',
     'config.json')
@@ -14,7 +14,7 @@
 # The location of the file that we'll store the Access Token SecureString
 # which cannot/should not roam with the user.
 [string] $script:accessTokenFilePath = [System.IO.Path]::Combine(
-    [Environment]::GetFolderPath('LocalApplicationData'),
+    [System.Environment]::GetFolderPath('LocalApplicationData'),
     'Microsoft',
     'PowerShellForGitHub',
     'accessToken.txt')
@@ -655,7 +655,7 @@ function Import-GitHubConfiguration
     $logToLocalAppDataFolder = [System.String]::IsNullOrEmpty($documentsFolder)
     if ($logToLocalAppDataFolder)
     {
-        $logPath = Join-Path -Path ([Environment]::GetFolderPath('LocalApplicationData')) -ChildPath $logName
+        $logPath = Join-Path -Path ([System.Environment]::GetFolderPath('LocalApplicationData')) -ChildPath $logName
     }
     else
     {
@@ -711,7 +711,7 @@ function Import-GitHubConfiguration
         # Limited instance where we write the warning directly instead of using Write-Log, since
         # Write-Log won't yet be configured.
         $message = "Storing log at non-default location: [$logPath] (no user profile path was found).  You can change this location by calling Set-GitHubConfiguration -LogPath <desiredPathToLogFile>"
-        Write-Warning -Message $message
+        Write-Verbose -Message $message
     }
 
     return $config

--- a/GitHubConfiguration.ps1
+++ b/GitHubConfiguration.ps1
@@ -655,7 +655,7 @@ function Import-GitHubConfiguration
     $logToLocalAppDataFolder = [System.String]::IsNullOrEmpty($documentsFolder)
     if ($logToLocalAppDataFolder)
     {
-        $logPath = Join-Path -Path [Environment]::GetFolderPath('LocalApplicationData') -ChildPath $logName
+        $logPath = Join-Path -Path ([Environment]::GetFolderPath('LocalApplicationData')) -ChildPath $logName
     }
     else
     {

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,7 +137,8 @@ The logging is affected by configuration properties (which can be checked with
 `Get-GitHubConfiguration` and changed with `Set-GitHubConfiguration`).
 
  **`LogPath`** [string] The logfile. Defaults to
-   `$env:USERPROFILE\Documents\PowerShellForGitHub.log`
+   `$env:USERPROFILE\Documents\PowerShellForGitHub.log`.  Will default to
+   `$env:TEMP\PowerShellForGitHub.log` when there is no user profile (like in an Azure environment).
 
  **`DisableLogging`** [bool] Defaults to `$false`.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -137,9 +137,9 @@ The logging is affected by configuration properties (which can be checked with
 `Get-GitHubConfiguration` and changed with `Set-GitHubConfiguration`).
 
  **`LogPath`** [string] The logfile. Defaults to
-   `$env:USERPROFILE\Documents\PowerShellForGitHub.log`.  Will default to
-   `[Environment]::GetFolderPath('LocalApplicationData')\PowerShellForGitHub.log` when there is no
-   user profile (like in an Azure environment).
+   `([System.Environment]::GetFolderPath('MyDocuments'))\PowerShellForGitHub.log`.  Will default to
+   `([System.Environment]::GetFolderPath('LocalApplicationData'))\PowerShellForGitHub.log` when
+   there is no user profile (like in an Azure environment).
 
  **`DisableLogging`** [bool] Defaults to `$false`.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -138,7 +138,8 @@ The logging is affected by configuration properties (which can be checked with
 
  **`LogPath`** [string] The logfile. Defaults to
    `$env:USERPROFILE\Documents\PowerShellForGitHub.log`.  Will default to
-   `$env:TEMP\PowerShellForGitHub.log` when there is no user profile (like in an Azure environment).
+   `[Environment]::GetFolderPath('LocalApplicationData')\PowerShellForGitHub.log` when there is no
+   user profile (like in an Azure environment).
 
  **`DisableLogging`** [bool] Defaults to `$false`.
 


### PR DESCRIPTION
#### Description
In Azure Function Apps, the special `MyDocuments` folder resolves to an empty string, which means that the default `logPath` gets stored as an empty string.

https://github.com/microsoft/PowerShellForGitHub/blob/3094c9789caf00382134a0703344f655b13a1e33/GitHubConfiguration.ps1#L650-L657

https://github.com/microsoft/PowerShellForGitHub/blob/3094c9789caf00382134a0703344f655b13a1e33/GitHubConfiguration.ps1#L671

This causes problems when `Write-Log` is called by any other function, because we directly assign the current configuration value for `LogPath` as the parameter's default, which throws an exception when an empty string is assigned.

https://github.com/microsoft/PowerShellForGitHub/blob/3094c9789caf00382134a0703344f655b13a1e33/Helpers.ps1#L142

In this scenario, we'll fall back to using the `LocalApplicationDataFolder` folder and writing a warning out to the user letting them know this has happened.

Documentation has also been updated to reflect this behavior change.

#### Issues Fixed
Resolves #282

#### References
n/a

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [x] ~~[Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.~~
- [x] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [x] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~
- [x] ~~Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.~~
- [x] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [x] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
