### PR TITLE
Fix gist test validating the since parameter

### DIFF
--- a/Tests/GitHubGists.tests.ps1
+++ b/Tests/GitHubGists.tests.ps1
@@ -238,7 +238,7 @@ try
                 }
             }
 
-            $since = (Get-Date -Date '01/01/2016')
+            $since = $gists.updated_At | Sort-Object | Select-Object -Last 1
             $sinceGists = Get-GitHubGist -UserName $username -Since $since
             It 'Should have fewer results with using the since parameter' {
                 $sinceGists.Count | Should -BeGreaterThan 0


### PR DESCRIPTION
#### Description
octocat recently updated all of its gists, starting on 2/24/2021.
The test previously would query for gists that were updated since 2016, but as of 2/24/2021, that included all of them.

The test has been made more robust by choosing the most recent date of all the gists and then requerying, which should hopefully now always guarantee that we'll get a reduced set of gists, unless all of the gists are suddenly updated in the future at the exact same second.

#### Issues Fixed
n/a

#### References
[gist reference](https://docs.github.com/en/rest/reference/gists#get-a-gist)

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [x] ~~[Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.~~
- [x] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [x] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- [x] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [x] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
