### PR TITLE
Not forwarding AccessToken to sub-commands for Repo Team Permissions

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -3070,7 +3070,7 @@ filter Get-GitHubRepositoryTeamPermission
 
     if ($PSBoundParameters.ContainsKey('TeamName'))
     {
-        $team = Get-GitHubTeam -OrganizationName $OwnerName |
+        $team = Get-GitHubTeam -OrganizationName $OwnerName -AccessToken $AccessToken |
             Where-Object -Property name -eq $TeamName
 
         if ($null -eq $team)
@@ -3104,7 +3104,7 @@ filter Get-GitHubRepositoryTeamPermission
 
     if ($PSBoundParameters.ContainsKey('TeamSlug'))
     {
-        $team = Get-GitHubTeam -OrganizationName $OwnerName -TeamSlug $TeamSlug
+        $team = Get-GitHubTeam -OrganizationName $OwnerName -TeamSlug $TeamSlug -AccessToken $AccessToken
 
         $TeamName = $team.name
     }
@@ -3253,7 +3253,7 @@ filter Set-GitHubRepositoryTeamPermission
 
     if ($PSBoundParameters.ContainsKey('TeamName'))
     {
-        $team = Get-GitHubTeam -OrganizationName $OwnerName |
+        $team = Get-GitHubTeam -OrganizationName $OwnerName -AccessToken $AccessToken |
             Where-Object -Property name -eq $TeamName
 
         if ($null -eq $team)
@@ -3426,7 +3426,7 @@ filter Remove-GitHubRepositoryTeamPermission
 
     if ($PSBoundParameters.ContainsKey('TeamName'))
     {
-        $team = Get-GitHubTeam -OrganizationName $OwnerName |
+        $team = Get-GitHubTeam -OrganizationName $OwnerName -AccessToken $AccessToken |
             Where-Object -Property name -eq $TeamName
 
         if ($null -eq $team)


### PR DESCRIPTION
#### Description

The Get/Set/Remove-GitHubRepositoryTeamPermission functions will sometimes call Get-GitHubTeam to get missing information.  In those instances, they weren't passing along the `AccessToken` parameter if it had been provided by the user.  In those scenarios, the result will be a 404 since the Get-GitHubTeam call won't have the same auth permissions as the core API being called.

#### Issues Fixed

Fixes #353

#### Checklist

- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] ~~Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [x] ~~[Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.~~
- [x] ~~New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- [x] ~~Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] ~~Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.~~
- [x] ~~Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- [x] ~~If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
