### PR TITLE
Revert "New/Set-GitHubRepository: Add AllowAutoMerge and UseSquashPrTitleAsDefault Parameters"

### DIFF
--- a/GitHubRepositories.ps1
+++ b/GitHubRepositories.ps1
@@ -83,13 +83,6 @@ filter New-GitHubRepository
         By default, rebase-merge pull requests will be allowed.
         Specify this to disallow.
 
-    .PARAMETER AllowAutoMerge
-        Specifies whether to allow auto-merge on pull requests.
-
-    .PARAMETER UseSquashPrTitleAsDefault
-        Specifies whether to use the pull request title for squash-merge commits rather than the
-        commit message.
-
     .PARAMETER DeleteBranchOnMerge
         Specifies the automatic deleting of head branches when pull requests are merged.
 
@@ -167,10 +160,6 @@ filter New-GitHubRepository
 
         [switch] $DisallowRebaseMerge,
 
-        [switch] $AllowAutoMerge,
-
-        [switch] $UseSquashPrTitleAsDefault,
-
         [switch] $DeleteBranchOnMerge,
 
         [switch] $IsTemplate,
@@ -216,8 +205,6 @@ filter New-GitHubRepository
     if ($PSBoundParameters.ContainsKey('DisallowSquashMerge')) { $hashBody['allow_squash_merge'] = (-not $DisallowSquashMerge.ToBool()) }
     if ($PSBoundParameters.ContainsKey('DisallowMergeCommit')) { $hashBody['allow_merge_commit'] = (-not $DisallowMergeCommit.ToBool()) }
     if ($PSBoundParameters.ContainsKey('DisallowRebaseMerge')) { $hashBody['allow_rebase_merge'] = (-not $DisallowRebaseMerge.ToBool()) }
-    if ($PSBoundParameters.ContainsKey('AllowAutoMerge')) { $hashBody['allow_auto_merge'] = $AllowAutoMerge.ToBool() }
-    if ($PSBoundParameters.ContainsKey('UseSquashPrTitleAsDefault')) { $hashBody['use_squash_pr_title_as_default'] = $UseSquashPrTitleAsDefault.ToBool() }
     if ($PSBoundParameters.ContainsKey('DeleteBranchOnMerge')) { $hashBody['delete_branch_on_merge'] = $DeleteBranchOnMerge.ToBool() }
     if ($PSBoundParameters.ContainsKey('IsTemplate')) { $hashBody['is_template'] = $IsTemplate.ToBool() }
 
@@ -1070,13 +1057,6 @@ filter Set-GitHubRepository
         By default, rebase-merge pull requests will be allowed.
         Specify this to disallow.
 
-    .PARAMETER AllowAutoMerge
-        Specifies whether to allow auto-merge on pull requests.
-
-    .PARAMETER UseSquashPrTitleAsDefault
-        Specifies whether to use the pull request title for squash-merge commits rather than the
-        commit message.
-
     .PARAMETER DeleteBranchOnMerge
         Specifies the automatic deleting of head branches when pull requests are merged.
 
@@ -1179,10 +1159,6 @@ filter Set-GitHubRepository
 
         [switch] $DisallowRebaseMerge,
 
-        [switch] $AllowAutoMerge,
-
-        [switch] $UseSquashPrTitleAsDefault,
-
         [switch] $DeleteBranchOnMerge,
 
         [switch] $IsTemplate,
@@ -1227,8 +1203,6 @@ filter Set-GitHubRepository
     if ($PSBoundParameters.ContainsKey('DisallowSquashMerge')) { $hashBody['allow_squash_merge'] = (-not $DisallowSquashMerge.ToBool()) }
     if ($PSBoundParameters.ContainsKey('DisallowMergeCommit')) { $hashBody['allow_merge_commit'] = (-not $DisallowMergeCommit.ToBool()) }
     if ($PSBoundParameters.ContainsKey('DisallowRebaseMerge')) { $hashBody['allow_rebase_merge'] = (-not $DisallowRebaseMerge.ToBool()) }
-    if ($PSBoundParameters.ContainsKey('AllowAutoMerge')) { $hashBody['allow_auto_merge'] = $AllowAutoMerge.ToBool() }
-    if ($PSBoundParameters.ContainsKey('UseSquashPrTitleAsDefault')) { $hashBody['use_squash_pr_title_as_default'] = $UseSquashPrTitleAsDefault.ToBool() }
     if ($PSBoundParameters.ContainsKey('DeleteBranchOnMerge')) { $hashBody['delete_branch_on_merge'] = $DeleteBranchOnMerge.ToBool() }
     if ($PSBoundParameters.ContainsKey('IsTemplate')) { $hashBody['is_template'] = $IsTemplate.ToBool() }
     if ($PSBoundParameters.ContainsKey('Archived')) { $hashBody['archived'] = $Archived.ToBool() }

--- a/Tests/GitHubRepositories.tests.ps1
+++ b/Tests/GitHubRepositories.tests.ps1
@@ -119,8 +119,6 @@ try
                         DisallowSquashMerge = $true
                         DisallowMergeCommit = $true
                         DisallowRebaseMerge = $false
-                        AllowAutoMerge = $true
-                        UseSquashPrTitleAsDefault = $true
                         DeleteBranchOnMerge = $true
                         GitIgnoreTemplate = $testGitIgnoreTemplate
                         LicenseTemplate = $testLicenseTemplate
@@ -144,8 +142,6 @@ try
                     $repo.allow_squash_merge | Should -BeFalse
                     $repo.allow_merge_commit | Should -BeFalse
                     $repo.allow_rebase_merge | Should -BeTrue
-                    $repo.allow_auto_merge | Should -BeTrue
-                    $repo.use_squash_pr_title_as_default | Should -BeTrue
                     $repo.delete_branch_on_merge | Should -BeTrue
                     $repo.is_template | Should -BeTrue
                 }
@@ -174,8 +170,6 @@ try
                         DisallowSquashMerge = $true
                         DisallowMergeCommit = $false
                         DisallowRebaseMerge = $true
-                        AllowAutoMerge = $false
-                        UseSquashPrTitleAsDefault = $false
                     }
                     $repo = New-GitHubRepository @newGitHubRepositoryParms
                 }
@@ -189,8 +183,6 @@ try
                     $repo.allow_squash_merge | Should -BeFalse
                     $repo.allow_merge_commit | Should -BeTrue
                     $repo.allow_rebase_merge | Should -BeFalse
-                    $repo.allow_auto_merge | Should -BeFalse
-                    $repo.use_squash_pr_title_as_default | Should -BeFalse
                 }
 
                 AfterAll -ScriptBlock {
@@ -737,8 +729,6 @@ try
                         DisallowMergeCommit = $true
                         DisallowRebaseMerge = $false
                         DeleteBranchOnMerge = $true
-                        AllowAutoMerge = $true
-                        UseSquashPrTitleAsDefault = $true
                         IsTemplate = $true
                     }
 
@@ -760,8 +750,6 @@ try
                     $updatedRepo.allow_squash_merge | Should -BeFalse
                     $updatedRepo.allow_merge_commit | Should -BeFalse
                     $updatedRepo.allow_rebase_merge | Should -BeTrue
-                    $updatedRepo.allow_auto_merge | Should -BeTrue
-                    $updatedRepo.use_squash_pr_title_as_default | Should -BeTrue
                     $updatedRepo.delete_branch_on_merge | Should -BeTrue
                     $updatedRepo.is_template | Should -BeTrue
                 }
@@ -775,8 +763,6 @@ try
                         DisallowSquashMerge = $true
                         DisallowMergeCommit = $false
                         DisallowRebaseMerge = $true
-                        AllowAutoMerge = $false
-                        UseSquashPrTitleAsDefault = $false
                     }
 
                     $updatedRepo = Set-GitHubRepository @updateGithubRepositoryParms -PassThru
@@ -791,8 +777,6 @@ try
                     $updatedRepo.allow_squash_merge | Should -BeFalse
                     $updatedRepo.allow_merge_commit | Should -BeTrue
                     $updatedRepo.allow_rebase_merge | Should -BeFalse
-                    $updatedRepo.use_squash_pr_title_as_default | Should -BeFalse
-                    $updatedRepo.delete_branch_on_merge | Should -BeFalse
                 }
             }
 


### PR DESCRIPTION
Reverts microsoft/PowerShellForGitHub#358

It turns out that this isn't quite working right.

The `use_squash_pr_title_as_default` parameter [has been deprecated per the documentation](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#update-a-repository) in favor of `squash_merge_commit_title ` which works a bit differently.

Additionally, there appears to be a GitHub-side bug at the moment with changing the value of `allow_auto_merge` (it does not honor the request being sent).

Given this, for the time being we'll revert the change until we know that the feature is working correctly.

/cc: @X-Guardian 