### PR TITLE
Remove static analysis warning for using a module alias being referenced in a test

### DIFF
--- a/Tests/GitHubDeployments.tests.ps1
+++ b/Tests/GitHubDeployments.tests.ps1
@@ -9,6 +9,8 @@
 [CmdletBinding()]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '',
     Justification = 'Suppress false positives in Pester code blocks')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingCmdletAliases', '',
+    Justification = 'Using Set-GitHubDeploymentEnvironment the way a user would.')]
 param()
 
 Set-StrictMode -Version 1.0


### PR DESCRIPTION
#### Description

I generally don't like aliases being used (neither does PSScriptAnalyzer), but in this case, `New-GitHubDeploymentEnvironment` was writting to be able to behave as `Set-GitHubDeploymentEnvironment` as well, and we should be testing it the way that a user would likely be calling it.

#### Checklist
- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- ~~[ ] Comment-based help added/updated, including examples.~~
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- ~~[ ] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).~~
- ~~[ ] [Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.~~
- ~~[ ] New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).~~
- ~~[ ] Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).~~
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- ~~[ ] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).~~
- ~~[ ] If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)~~
