### PR TITLE
Replace `BinaryFormatter` with `PSSerializer`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,7 +422,7 @@ Pester can also be used to test code-coverage, like so:
 
 ```powershell
 $pesterConfig = New-PesterConfiguration
-$pesterConfig.CodeCoverage.Path = @("$root\GitHubLabels.ps1") 
+$pesterConfig.CodeCoverage.Path = @("$root\GitHubLabels.ps1")
 $pesterConfig.CodeCoverage.Enabled = $true
 
 Invoke-Pester -Configuration $pesterConfig
@@ -435,7 +435,7 @@ The code-coverage object can be captured and interacted with, like so:
 
 ```powershell
 $pesterConfig = New-PesterConfiguration
-$pesterConfig.CodeCoverage.Path = @("$root\GitHubLabels.ps1") 
+$pesterConfig.CodeCoverage.Path = @("$root\GitHubLabels.ps1")
 $pesterConfig.CodeCoverage.Enabled = $true
 $pesterConfig.Run.PassThru = $true
 
@@ -625,6 +625,7 @@ Thank you to all of our contributors, no matter how big or small the contributio
 - **[Neil White (@variableresistor)](https://github.com/variableresistor)**
 - **[Mark Curole(@tigerfansga)](https://github.com/tigerfansga)**
 - **[Jason Vercellone(@vercellone)](https://github.com/vercellone)**
+- **[Andy Jordan (@andyleejordan)](https://github.com/andyleejordan)**
 
 ----------
 

--- a/Helpers.ps1
+++ b/Helpers.ps1
@@ -394,14 +394,8 @@ function DeepCopy-Object
         [PSCustomObject] $InputObject
     )
 
-    $memoryStream = New-Object System.IO.MemoryStream
-    $binaryFormatter = New-Object System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-    $binaryFormatter.Serialize($memoryStream, $InputObject)
-    $memoryStream.Position = 0
-    $DeepCopiedObject = $binaryFormatter.Deserialize($memoryStream)
-    $memoryStream.Close()
-
-    return $DeepCopiedObject
+    $serialData = [System.Management.Automation.PSSerializer]::Serialize($InputObject, 64)
+    return [System.Management.Automation.PSSerializer]::Deserialize($serialData)
 }
 
 function New-TemporaryDirectory


### PR DESCRIPTION
#### Description

Since the former has been removed from PowerShell 7.4 (because it was removed from .NET 7) and the latter can accomplish the same thing.

#### Issues Fixed

- Fixes #413

#### References

N/A

#### Checklist

- [x] You actually ran the code that you just wrote, especially if you did just "one last quick change".
- [x] Comment-based help added/updated, including examples.
- [x] [Static analysis](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#static-analysis) is reporting back clean.
- [x] New/changed code adheres to our [coding guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#coding-guidelines).
- [x] [Formatters were created](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#formatters) for any new types being added.
- [x] New/changed code continues to [support the pipeline](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#pipeline-support).
- [x] Changes to the manifest file follow the [manifest guidance](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#module-manifest).
- [x] Unit tests were added/updated and are all passing. See [testing guidelines](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#testing).  This includes making sure that all pipeline input variations have been covered.
- [x] Relevant usage examples have been added/updated in [USAGE.md](https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md).
- [x] If desired, ensure your name is added to our [Contributors list](https://github.com/microsoft/PowerShellForGitHub/blob/master/CONTRIBUTING.md#contributors)
